### PR TITLE
docs: use HEX values for React color props

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ npm i @paper-design/shaders
 import { MeshGradient } from '@paper-design/shaders-react';
 
 <MeshGradient
-  color1="pink"
-  color2="white"
-  color3="blue"
-  color4="purple"
+  color1="#FFC0CB" // pink
+  color2="#FFFF00" // yellow
+  color3="#0000FF" // blue
+  color4="#800080" // purple
   speed={0.25}
   style={{ width: 500, height: 200 }} />
 
@@ -58,10 +58,10 @@ import { MeshGradient } from '@paper-design/shaders-react';
 import { MeshGradient } from '@paper-design/shaders-react';
 
 <MeshGradient
-  color1="pink"
-  color2="white"
-  color3="blue"
-  color4="purple"
+  color1="#FFC0CB" // pink
+  color2="#FFFF00" // yellow
+  color3="#0000FF" // blue
+  color4="#800080" // purple
   speed={0.25}
   style={{ width: 500, height: 200 }} />
 


### PR DESCRIPTION
Not sure if this is a bug, but if you copy/paste the current React `MeshGradient` snippet into your app, it'll blow up with a bunch of errors about unsupported color formats.

![CleanShot 2024-12-05 at 13 53 16@2x](https://github.com/user-attachments/assets/a24ce715-e965-49fe-b198-17495cecc5ff)

I've updated to HEX and it seems to be working again. Happy to use different HEX values if this is the right approach but a bad example of colors.