### PR TITLE
Smoke ring presets: cloud, fire, electric, poison

### DIFF
--- a/example/src/shaders/smoke-ring-example.tsx
+++ b/example/src/shaders/smoke-ring-example.tsx
@@ -36,7 +36,7 @@ export const SmokeRingWithControls = () => {
           colorBack: { value: defaults.colorBack, order: 1 },
           color1: { value: defaults.color1, order: 2 },
           color2: { value: defaults.color2, order: 3 },
-          speed: { value: defaults.speed, order: 4, min: 0, max: 1.5 },
+          speed: { value: defaults.speed, order: 4, min: 0, max: 4 },
           thickness: { value: defaults.thickness, order: 5, min: 0.1, max: 2 },
           noiseScale: { value: defaults.thickness, order: 6, min: 0.01, max: 5 },
         },

--- a/packages/shaders-react/src/shaders/smoke-ring.tsx
+++ b/packages/shaders-react/src/shaders/smoke-ring.tsx
@@ -17,16 +17,70 @@ type SmokeRingPreset = { name: string; params: Required<SmokeRingParams> };
 export const defaultPreset: SmokeRingPreset = {
   name: 'Default',
   params: {
-    colorBack: 'hsla(0, 0%, 0%, 1)',
-    color1: 'hsla(0, 0%, 100%, 1)',
-    color2: 'hsla(211, 100%, 64%, 1)',
+    colorBack: 'hsla(208, 54%, 7%)',
+    color1: 'hsla(0, 0%, 100%)',
+    color2: 'hsla(211, 100%, 64%)',
     speed: 1,
     noiseScale: 1.4,
     thickness: 0.33,
   },
 } as const;
 
-export const smokeRingPresets: SmokeRingPreset[] = [defaultPreset];
+export const cloudPreset: SmokeRingPreset = {
+  name: 'Cloud',
+  params: {
+    colorBack: 'hsla(218, 100%, 62%)',
+    color1: 'hsla(0, 0%, 100%)',
+    color2: 'hsla(0, 0%, 100%)',
+    speed: 1,
+    thickness: 0.7,
+    noiseScale: 1.8,
+  },
+};
+
+export const firePreset: SmokeRingPreset = {
+  name: 'Fire',
+  params: {
+    colorBack: 'hsla(20, 100%, 5%)',
+    color1: 'hsla(40, 100%, 50%)',
+    color2: 'hsla(0, 100%, 50%)',
+    speed: 4,
+    thickness: 0.35,
+    noiseScale: 1.4,
+  },
+};
+
+export const electricPreset: SmokeRingPreset = {
+  name: 'Electric',
+  params: {
+    colorBack: 'hsla(47, 50%, 7%)',
+    color1: 'hsla(47, 100%, 64%)',
+    color2: 'hsla(47, 100%, 64%)',
+    speed: 2.5,
+    thickness: 0.1,
+    noiseScale: 1.8,
+  },
+};
+
+export const poisonPreset: SmokeRingPreset = {
+  name: 'Poison',
+  params: {
+    colorBack: 'hsla(120, 100%, 3%)',
+    color1: 'hsla(120, 100%, 3%)',
+    color2: 'hsla(120, 100%, 66%)',
+    speed: 3,
+    thickness: 0.6,
+    noiseScale: 5,
+  },
+};
+
+export const smokeRingPresets: SmokeRingPreset[] = [
+  defaultPreset,
+  cloudPreset,
+  firePreset,
+  electricPreset,
+  poisonPreset,
+];
 
 export const SmokeRing = (props: SmokeRingProps): JSX.Element => {
   const uniforms: SmokeRingUniforms = useMemo(() => {


### PR DESCRIPTION
Omitting alpha `1` in `hsla()` works the same as having it, so I removed it.

Live here: https://smoke-ring-presets.shaders.pages.dev/smoke-ring