### PR TITLE
Numbered presets buttons renaming

### DIFF
--- a/packages/shaders-react/src/shaders/dots-grid.tsx
+++ b/packages/shaders-react/src/shaders/dots-grid.tsx
@@ -43,7 +43,7 @@ export const defaultPreset: DotsGridPreset = {
 } as const;
 
 const preset1: DotsGridPreset = {
-  name: '1',
+  name: 'Preset #1',
   params: {
     // Note: Keep default colors in HSLA format so that our Leva controls show a transparency channel (rgba and hex8 do not work)
     colorBack: 'hsla(0, 0%, 100%, 1)',
@@ -60,7 +60,7 @@ const preset1: DotsGridPreset = {
 } as const;
 
 const preset2: DotsGridPreset = {
-  name: '2',
+  name: 'Preset #2',
   params: {
     // Note: Keep default colors in HSLA format so that our Leva controls show a transparency channel (rgba and hex8 do not work)
     colorBack: 'hsla(234, 100%, 31%, .5)',
@@ -77,7 +77,7 @@ const preset2: DotsGridPreset = {
 } as const;
 
 const preset3: DotsGridPreset = {
-  name: '3',
+  name: 'Preset #3',
   params: {
     // Note: Keep default colors in HSLA format so that our Leva controls show a transparency channel (rgba and hex8 do not work)
     colorBack: 'hsla(100, 100%, 36%, .05)',
@@ -94,7 +94,7 @@ const preset3: DotsGridPreset = {
 } as const;
 
 const preset4: DotsGridPreset = {
-  name: '4',
+  name: 'Preset #4',
   params: {
     // Note: Keep default colors in HSLA format so that our Leva controls show a transparency channel (rgba and hex8 do not work)
     colorBack: 'hsla(0, 0%, 0%, 0)',
@@ -111,7 +111,7 @@ const preset4: DotsGridPreset = {
 } as const;
 
 const preset5: DotsGridPreset = {
-  name: '5',
+  name: 'Preset #5',
   params: {
     // Note: Keep default colors in HSLA format so that our Leva controls show a transparency channel (rgba and hex8 do not work)
     colorBack: 'hsla(154, 33%, 19%, 1)',
@@ -128,7 +128,7 @@ const preset5: DotsGridPreset = {
 } as const;
 
 const preset6: DotsGridPreset = {
-  name: '6',
+  name: 'Preset #6',
   params: {
     // Note: Keep default colors in HSLA format so that our Leva controls show a transparency channel (rgba and hex8 do not work)
     colorBack: 'hsla(0, 100%, 0%, 1)',
@@ -145,7 +145,7 @@ const preset6: DotsGridPreset = {
 } as const;
 
 const preset7: DotsGridPreset = {
-  name: '7',
+  name: 'Preset #7',
   params: {
     // Note: Keep default colors in HSLA format so that our Leva controls show a transparency channel (rgba and hex8 do not work)
     colorBack: 'hsla(0, 100%, 100%, 1)',

--- a/packages/shaders-react/src/shaders/dots-grid.tsx
+++ b/packages/shaders-react/src/shaders/dots-grid.tsx
@@ -43,7 +43,7 @@ export const defaultPreset: DotsGridPreset = {
 } as const;
 
 const preset1: DotsGridPreset = {
-  name: 'Preset #1',
+  name: 'Triangles',
   params: {
     // Note: Keep default colors in HSLA format so that our Leva controls show a transparency channel (rgba and hex8 do not work)
     colorBack: 'hsla(0, 0%, 100%, 1)',
@@ -60,7 +60,7 @@ const preset1: DotsGridPreset = {
 } as const;
 
 const preset2: DotsGridPreset = {
-  name: 'Preset #2',
+  name: 'Bubbles',
   params: {
     // Note: Keep default colors in HSLA format so that our Leva controls show a transparency channel (rgba and hex8 do not work)
     colorBack: 'hsla(234, 100%, 31%, .5)',
@@ -77,7 +77,7 @@ const preset2: DotsGridPreset = {
 } as const;
 
 const preset3: DotsGridPreset = {
-  name: 'Preset #3',
+  name: 'Tree line',
   params: {
     // Note: Keep default colors in HSLA format so that our Leva controls show a transparency channel (rgba and hex8 do not work)
     colorBack: 'hsla(100, 100%, 36%, .05)',
@@ -94,7 +94,7 @@ const preset3: DotsGridPreset = {
 } as const;
 
 const preset4: DotsGridPreset = {
-  name: 'Preset #4',
+  name: 'Diamonds',
   params: {
     // Note: Keep default colors in HSLA format so that our Leva controls show a transparency channel (rgba and hex8 do not work)
     colorBack: 'hsla(0, 0%, 0%, 0)',
@@ -111,7 +111,7 @@ const preset4: DotsGridPreset = {
 } as const;
 
 const preset5: DotsGridPreset = {
-  name: 'Preset #5',
+  name: 'Wallpaper',
   params: {
     // Note: Keep default colors in HSLA format so that our Leva controls show a transparency channel (rgba and hex8 do not work)
     colorBack: 'hsla(154, 33%, 19%, 1)',
@@ -128,7 +128,7 @@ const preset5: DotsGridPreset = {
 } as const;
 
 const preset6: DotsGridPreset = {
-  name: 'Preset #6',
+  name: 'Enter the Matrix',
   params: {
     // Note: Keep default colors in HSLA format so that our Leva controls show a transparency channel (rgba and hex8 do not work)
     colorBack: 'hsla(0, 100%, 0%, 1)',
@@ -145,7 +145,7 @@ const preset6: DotsGridPreset = {
 } as const;
 
 const preset7: DotsGridPreset = {
-  name: 'Preset #7',
+  name: 'Waveform',
   params: {
     // Note: Keep default colors in HSLA format so that our Leva controls show a transparency channel (rgba and hex8 do not work)
     colorBack: 'hsla(0, 100%, 100%, 1)',

--- a/packages/shaders-react/src/shaders/perlin-noise.tsx
+++ b/packages/shaders-react/src/shaders/perlin-noise.tsx
@@ -35,7 +35,7 @@ export const defaultPreset: PerlinNoisePreset = {
 };
 
 export const preset1: PerlinNoisePreset = {
-  name: 'Preset #1',
+  name: 'Nintendo Water',
   params: {
     // Note: Keep default colors in HSLA format so that our Leva controls show a transparency channel (rgba and hex8 do not work)
     color1: 'hsla(220, 66%, 50%, 1)',
@@ -52,7 +52,7 @@ export const preset1: PerlinNoisePreset = {
 };
 
 export const preset2: PerlinNoisePreset = {
-  name: 'Preset #2',
+  name: 'Colony',
   params: {
     // Note: Keep default colors in HSLA format so that our Leva controls show a transparency channel (rgba and hex8 do not work)
     color1: 'hsla(56, 86%, 81%, 1)',
@@ -69,7 +69,7 @@ export const preset2: PerlinNoisePreset = {
 };
 
 export const preset3: PerlinNoisePreset = {
-  name: 'Preset #3',
+  name: 'Phosphenes',
   params: {
     // Note: Keep default colors in HSLA format so that our Leva controls show a transparency channel (rgba and hex8 do not work)
     color1: 'hsla(350, 80%, 70%, 1)',
@@ -86,7 +86,7 @@ export const preset3: PerlinNoisePreset = {
 } as const;
 
 export const preset4: PerlinNoisePreset = {
-  name: 'Preset #4',
+  name: 'Moss',
   params: {
     // Note: Keep default colors in HSLA format so that our Leva controls show a transparency channel (rgba and hex8 do not work)
     color1: 'hsla(137, 100%, 51%, 1)',
@@ -103,7 +103,7 @@ export const preset4: PerlinNoisePreset = {
 } as const;
 
 export const preset5: PerlinNoisePreset = {
-  name: 'Preset #5',
+  name: 'Worms',
   params: {
     // Note: Keep default colors in HSLA format so that our Leva controls show a transparency channel (rgba and hex8 do not work)
     color1: 'hsla(0, 100%, 100%, 1)',

--- a/packages/shaders-react/src/shaders/perlin-noise.tsx
+++ b/packages/shaders-react/src/shaders/perlin-noise.tsx
@@ -35,7 +35,7 @@ export const defaultPreset: PerlinNoisePreset = {
 };
 
 export const preset1: PerlinNoisePreset = {
-  name: '1',
+  name: 'Preset #1',
   params: {
     // Note: Keep default colors in HSLA format so that our Leva controls show a transparency channel (rgba and hex8 do not work)
     color1: 'hsla(220, 66%, 50%, 1)',
@@ -52,7 +52,7 @@ export const preset1: PerlinNoisePreset = {
 };
 
 export const preset2: PerlinNoisePreset = {
-  name: '2',
+  name: 'Preset #2',
   params: {
     // Note: Keep default colors in HSLA format so that our Leva controls show a transparency channel (rgba and hex8 do not work)
     color1: 'hsla(56, 86%, 81%, 1)',
@@ -69,7 +69,7 @@ export const preset2: PerlinNoisePreset = {
 };
 
 export const preset3: PerlinNoisePreset = {
-  name: '3',
+  name: 'Preset #3',
   params: {
     // Note: Keep default colors in HSLA format so that our Leva controls show a transparency channel (rgba and hex8 do not work)
     color1: 'hsla(350, 80%, 70%, 1)',
@@ -86,7 +86,7 @@ export const preset3: PerlinNoisePreset = {
 } as const;
 
 export const preset4: PerlinNoisePreset = {
-  name: '4',
+  name: 'Preset #4',
   params: {
     // Note: Keep default colors in HSLA format so that our Leva controls show a transparency channel (rgba and hex8 do not work)
     color1: 'hsla(137, 100%, 51%, 1)',
@@ -103,7 +103,7 @@ export const preset4: PerlinNoisePreset = {
 } as const;
 
 export const preset5: PerlinNoisePreset = {
-  name: '5',
+  name: 'Preset #5',
   params: {
     // Note: Keep default colors in HSLA format so that our Leva controls show a transparency channel (rgba and hex8 do not work)
     color1: 'hsla(0, 100%, 100%, 1)',


### PR DESCRIPTION
There was a weird bug with Leva buttons if they simply named with numbers. I don't think the bug itself needs investigation, as seems to be working fine with different naming