### PR TITLE
Checking if XxxUniforms type can be removed

### DIFF
--- a/packages/shaders-react/src/index.ts
+++ b/packages/shaders-react/src/index.ts
@@ -7,79 +7,68 @@ export { ShaderMount } from './shader-mount';
 export { GrainClouds, grainCloudsPresets } from './shaders/grain-clouds';
 export { type GrainCloudsProps } from './shaders/grain-clouds';
 export { type GrainCloudsParams } from './shaders/grain-clouds';
-export { type GrainCloudsUniforms } from '@paper-design/shaders';
 
 // Mesh gradient
 export { MeshGradient, meshGradientPresets } from './shaders/mesh-gradient';
 export { type MeshGradientProps } from './shaders/mesh-gradient';
 export { type MeshGradientParams } from './shaders/mesh-gradient';
-export { type MeshGradientUniforms } from '@paper-design/shaders';
 
 // Smoke ring
 export { SmokeRing, smokeRingPresets } from './shaders/smoke-ring';
 export { type SmokeRingProps } from './shaders/smoke-ring';
 export { type SmokeRingParams } from './shaders/smoke-ring';
-export { type SmokeRingUniforms } from '@paper-design/shaders';
 
 // Neuro noise
 export { NeuroNoise, neuroNoisePresets } from './shaders/neuro-noise';
 export { type NeuroNoiseProps } from './shaders/neuro-noise';
 export { type NeuroNoiseParams } from './shaders/neuro-noise';
-export { type NeuroNoiseUniforms } from '@paper-design/shaders';
 
 // Animated dots pattern: orbit type of animation
 export { DotsOrbit, dotsOrbitPresets } from './shaders/dots-orbit';
 export { type DotsOrbitProps } from './shaders/dots-orbit';
 export { type DotsOrbitParams } from './shaders/dots-orbit';
-export { type DotsOrbitUniforms } from '@paper-design/shaders';
 
 // Dot Grid
 export { DotsGrid, dotsGridPresets } from './shaders/dots-grid';
 export { type DotsGridProps } from './shaders/dots-grid';
 export { type DotsGridParams } from './shaders/dots-grid';
-export { type DotsGridUniforms, DotsGridShapes, type DotsGridShape } from '@paper-design/shaders';
+export { DotsGridShapes, type DotsGridShape } from '@paper-design/shaders';
 
 // Stepped simplex noise
 export { SteppedSimplexNoise, steppedSimplexNoisePresets } from './shaders/stepped-simplex-noise';
 export { type SteppedSimplexNoiseProps } from './shaders/stepped-simplex-noise';
 export { type SteppedSimplexNoiseParams } from './shaders/stepped-simplex-noise';
-export { type SteppedSimplexNoiseUniforms } from '@paper-design/shaders';
 
 // Metaballs
 export { Metaballs, metaballsPresets } from './shaders/metaballs';
 export { type MetaballsProps } from './shaders/metaballs';
 export { type MetaballsParams } from './shaders/metaballs';
-export { type MetaballsUniforms } from '@paper-design/shaders';
 
 // Waves
 export { Waves, wavesPresets } from './shaders/waves';
 export { type WavesProps } from './shaders/waves';
 export { type WavesParams } from './shaders/waves';
-export { type WavesUniforms } from '@paper-design/shaders';
 
 // Perlin noise
 export { PerlinNoise, perlinNoisePresets } from './shaders/perlin-noise';
 export { type PerlinNoiseProps } from './shaders/perlin-noise';
 export { type PerlinNoiseParams } from './shaders/perlin-noise';
-export { type PerlinNoiseUniforms } from '@paper-design/shaders';
 
 // Voronoi diagram
 export { Voronoi, voronoiPresets } from './shaders/voronoi';
 export { type VoronoiProps } from './shaders/voronoi';
 export { type VoronoiParams } from './shaders/voronoi';
-export { type VoronoiUniforms } from '@paper-design/shaders';
 
 // Warping distortion
 export { Warp, warpPresets } from './shaders/warp';
 export { type WarpProps } from './shaders/warp';
 export { type WarpParams } from './shaders/warp';
-export { type WarpUniforms, PatternShapes, type PatternShape } from '@paper-design/shaders';
+export { type PatternShapes, type PatternShape } from '@paper-design/shaders';
 
 // God Rays effect
 export { GodRays, godRaysPresets } from './shaders/god-rays';
 export { type GodRaysProps } from './shaders/god-rays';
 export { type GodRaysParams } from './shaders/god-rays';
-export { type GodRaysUniforms } from '@paper-design/shaders';
 
 // ----- Uniform conversion utils ----- //
 export { getShaderColorFromString } from '@paper-design/shaders';

--- a/packages/shaders-react/src/shaders/dots-grid.tsx
+++ b/packages/shaders-react/src/shaders/dots-grid.tsx
@@ -3,7 +3,7 @@ import { ShaderMount, type ShaderMountProps } from '../shader-mount';
 import {
   dotsGridFragmentShader,
   getShaderColorFromString,
-  type DotsGridUniforms,
+  // type DotsGridUniforms,
   type DotsGridShape,
   DotsGridShapes,
 } from '@paper-design/shaders';
@@ -169,7 +169,7 @@ export const dotsGridPresets: DotsGridPreset[] = [
 ];
 
 export const DotsGrid = (props: DotsGridProps): JSX.Element => {
-  const uniforms: DotsGridUniforms = useMemo(() => {
+  const uniforms = useMemo(() => {
     return {
       u_colorBack: getShaderColorFromString(props.colorBack, defaultPreset.params.colorBack),
       u_colorFill: getShaderColorFromString(props.colorFill, defaultPreset.params.colorStroke),

--- a/packages/shaders-react/src/shaders/dots-orbit.tsx
+++ b/packages/shaders-react/src/shaders/dots-orbit.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { ShaderMount, type GlobalParams, type ShaderMountProps } from '../shader-mount';
-import { getShaderColorFromString, dotsOrbitFragmentShader, type DotsOrbitUniforms } from '@paper-design/shaders';
+import { getShaderColorFromString, dotsOrbitFragmentShader } from '@paper-design/shaders';
 
 export type DotsOrbitParams = {
   scale?: number;
@@ -40,7 +40,7 @@ export const defaultPreset: DotsOrbitPreset = {
 export const dotsOrbitPresets: DotsOrbitPreset[] = [defaultPreset];
 
 export const DotsOrbit = (props: DotsOrbitProps): JSX.Element => {
-  const uniforms: DotsOrbitUniforms = useMemo(() => {
+  const uniforms = useMemo(() => {
     return {
       u_scale: props.scale ?? defaultPreset.params.scale,
       u_color1: getShaderColorFromString(props.color1, defaultPreset.params.color1),

--- a/packages/shaders-react/src/shaders/god-rays.tsx
+++ b/packages/shaders-react/src/shaders/god-rays.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { ShaderMount, type GlobalParams, type ShaderMountProps } from '../shader-mount';
-import { getShaderColorFromString, godRaysFragmentShader, type GodRaysUniforms } from '@paper-design/shaders';
+import { getShaderColorFromString, godRaysFragmentShader } from '@paper-design/shaders';
 
 export type GodRaysParams = {
   colorBack?: string;
@@ -128,7 +128,7 @@ export const etherPreset: GodRaysPreset = {
 export const godRaysPresets: GodRaysPreset[] = [defaultPreset, auroraPreset, warpPreset, linearPreset, etherPreset];
 
 export const GodRays = (props: GodRaysProps): JSX.Element => {
-  const uniforms: GodRaysUniforms = useMemo(() => {
+  const uniforms = useMemo(() => {
     return {
       u_colorBack: getShaderColorFromString(props.colorBack, defaultPreset.params.colorBack),
       u_color1: getShaderColorFromString(props.color1, defaultPreset.params.color1),

--- a/packages/shaders-react/src/shaders/grain-clouds.tsx
+++ b/packages/shaders-react/src/shaders/grain-clouds.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { ShaderMount, type GlobalParams, type ShaderMountProps } from '../shader-mount';
-import { getShaderColorFromString, grainCloudsFragmentShader, type GrainCloudsUniforms } from '@paper-design/shaders';
+import { getShaderColorFromString, grainCloudsFragmentShader } from '@paper-design/shaders';
 
 export type GrainCloudsParams = {
   scale?: number;
@@ -44,7 +44,7 @@ export const skyPreset: GrainCloudsPreset = {
 export const grainCloudsPresets: GrainCloudsPreset[] = [defaultPreset, skyPreset];
 
 export const GrainClouds = (props: GrainCloudsProps): JSX.Element => {
-  const uniforms: GrainCloudsUniforms = useMemo(() => {
+  const uniforms = useMemo(() => {
     return {
       u_scale: props.scale ?? defaultPreset.params.scale,
       u_color1: getShaderColorFromString(props.color1, defaultPreset.params.color1),

--- a/packages/shaders-react/src/shaders/mesh-gradient.tsx
+++ b/packages/shaders-react/src/shaders/mesh-gradient.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { ShaderMount, type GlobalParams, type ShaderMountProps } from '../shader-mount';
-import { getShaderColorFromString, meshGradientFragmentShader, type MeshGradientUniforms } from '@paper-design/shaders';
+import { getShaderColorFromString, meshGradientFragmentShader } from '@paper-design/shaders';
 
 export type MeshGradientParams = {
   color1?: string;
@@ -56,7 +56,7 @@ export const fadedPreset: MeshGradientPreset = {
 export const meshGradientPresets: MeshGradientPreset[] = [defaultPreset, beachPreset, fadedPreset];
 
 export const MeshGradient = (props: MeshGradientProps): JSX.Element => {
-  const uniforms: MeshGradientUniforms = useMemo(() => {
+  const uniforms = useMemo(() => {
     return {
       u_color1: getShaderColorFromString(props.color1, defaultPreset.params.color1),
       u_color2: getShaderColorFromString(props.color2, defaultPreset.params.color2),

--- a/packages/shaders-react/src/shaders/metaballs.tsx
+++ b/packages/shaders-react/src/shaders/metaballs.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { ShaderMount, type GlobalParams, type ShaderMountProps } from '../shader-mount';
-import { getShaderColorFromString, metaballsFragmentShader, type MetaballsUniforms } from '@paper-design/shaders';
+import { getShaderColorFromString, metaballsFragmentShader } from '@paper-design/shaders';
 
 export type MetaballsParams = {
   scale?: number;
@@ -36,7 +36,7 @@ export const defaultPreset: MetaballsPreset = {
 export const metaballsPresets: MetaballsPreset[] = [defaultPreset];
 
 export const Metaballs = (props: MetaballsProps): JSX.Element => {
-  const uniforms: MetaballsUniforms = useMemo(() => {
+  const uniforms = useMemo(() => {
     return {
       u_scale: props.scale ?? defaultPreset.params.scale,
       u_color1: getShaderColorFromString(props.color1, defaultPreset.params.color1),

--- a/packages/shaders-react/src/shaders/neuro-noise.tsx
+++ b/packages/shaders-react/src/shaders/neuro-noise.tsx
@@ -1,6 +1,5 @@
 import { useMemo } from 'react';
 import { ShaderMount, type GlobalParams, type ShaderMountProps } from '../shader-mount';
-import { getShaderColorFromString, neuroNoiseFragmentShader, type NeuroNoiseUniforms } from '@paper-design/shaders';
 
 export type NeuroNoiseParams = {
   scale?: number;
@@ -44,7 +43,7 @@ const marblePreset: NeuroNoisePreset = {
 export const neuroNoisePresets: NeuroNoisePreset[] = [defaultPreset, marblePreset] as const;
 
 export const NeuroNoise = (props: NeuroNoiseProps): JSX.Element => {
-  const uniforms: NeuroNoiseUniforms = useMemo(() => {
+  const uniforms = useMemo(() => {
     return {
       u_scale: props.scale ?? defaultPreset.params.scale,
       u_colorFront: getShaderColorFromString(props.colorFront, defaultPreset.params.colorFront),

--- a/packages/shaders-react/src/shaders/neuro-noise.tsx
+++ b/packages/shaders-react/src/shaders/neuro-noise.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 import { ShaderMount, type GlobalParams, type ShaderMountProps } from '../shader-mount';
+import { getShaderColorFromString, neuroNoiseFragmentShader } from '@paper-design/shaders';
 
 export type NeuroNoiseParams = {
   scale?: number;

--- a/packages/shaders-react/src/shaders/perlin-noise.tsx
+++ b/packages/shaders-react/src/shaders/perlin-noise.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { ShaderMount, type GlobalParams, type ShaderMountProps } from '../shader-mount';
-import { getShaderColorFromString, perlinNoiseFragmentShader, type PerlinNoiseUniforms } from '@paper-design/shaders';
+import { getShaderColorFromString, perlinNoiseFragmentShader } from '@paper-design/shaders';
 
 export type PerlinNoiseParams = {
   scale?: number;
@@ -120,7 +120,7 @@ export const preset5: PerlinNoisePreset = {
 export const perlinNoisePresets: PerlinNoisePreset[] = [defaultPreset, preset1, preset2, preset3, preset4, preset5];
 
 export const PerlinNoise = (props: PerlinNoiseProps): JSX.Element => {
-  const uniforms: PerlinNoiseUniforms = useMemo(() => {
+  const uniforms = useMemo(() => {
     return {
       u_scale: props.scale ?? defaultPreset.params.scale,
       u_color1: getShaderColorFromString(props.color1, defaultPreset.params.color1),

--- a/packages/shaders-react/src/shaders/smoke-ring.tsx
+++ b/packages/shaders-react/src/shaders/smoke-ring.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { ShaderMount, type GlobalParams, type ShaderMountProps } from '../shader-mount';
-import { getShaderColorFromString, smokeRingFragmentShader, type SmokeRingUniforms } from '@paper-design/shaders';
+import { getShaderColorFromString, smokeRingFragmentShader } from '@paper-design/shaders';
 
 export type SmokeRingParams = {
   colorBack?: string;
@@ -98,7 +98,7 @@ export const smokeRingPresets: SmokeRingPreset[] = [
 ];
 
 export const SmokeRing = (props: SmokeRingProps): JSX.Element => {
-  const uniforms: SmokeRingUniforms = useMemo(() => {
+  const uniforms = useMemo(() => {
     return {
       u_scale: props.scale ?? defaultPreset.params.scale,
       u_colorBack: getShaderColorFromString(props.colorBack, defaultPreset.params.colorBack),

--- a/packages/shaders-react/src/shaders/stepped-simplex-noise.tsx
+++ b/packages/shaders-react/src/shaders/stepped-simplex-noise.tsx
@@ -1,10 +1,6 @@
 import { useMemo } from 'react';
 import { ShaderMount, type GlobalParams, type ShaderMountProps } from '../shader-mount';
-import {
-  getShaderColorFromString,
-  steppedSimplexNoiseFragmentShader,
-  type SteppedSimplexNoiseUniforms,
-} from '@paper-design/shaders';
+import { getShaderColorFromString, steppedSimplexNoiseFragmentShader } from '@paper-design/shaders';
 
 export type SteppedSimplexNoiseParams = {
   scale?: number;
@@ -92,7 +88,7 @@ export const steppedSimplexNoisePresets: SteppedSimplexNoisePreset[] = [
 ];
 
 export const SteppedSimplexNoise = (props: SteppedSimplexNoiseProps): JSX.Element => {
-  const uniforms: SteppedSimplexNoiseUniforms = useMemo(() => {
+  const uniforms = useMemo(() => {
     return {
       u_scale: props.scale ?? defaultPreset.params.scale,
       u_color1: getShaderColorFromString(props.color1, defaultPreset.params.color1),

--- a/packages/shaders-react/src/shaders/voronoi.tsx
+++ b/packages/shaders-react/src/shaders/voronoi.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { ShaderMount, type GlobalParams, type ShaderMountProps } from '../shader-mount';
-import { getShaderColorFromString, voronoiFragmentShader, type VoronoiUniforms } from '@paper-design/shaders';
+import { getShaderColorFromString, voronoiFragmentShader } from '@paper-design/shaders';
 
 export type VoronoiParams = {
   scale?: number;
@@ -197,7 +197,7 @@ export const voronoiPresets: VoronoiPreset[] = [
 ];
 
 export const Voronoi = (props: VoronoiProps): JSX.Element => {
-  const uniforms: VoronoiUniforms = useMemo(() => {
+  const uniforms = useMemo(() => {
     return {
       u_scale: props.scale ?? defaultPreset.params.scale,
       u_colorCell1: getShaderColorFromString(props.colorCell1, defaultPreset.params.colorCell1),

--- a/packages/shaders-react/src/shaders/warp.tsx
+++ b/packages/shaders-react/src/shaders/warp.tsx
@@ -1,12 +1,6 @@
 import { useMemo } from 'react';
 import { ShaderMount, type GlobalParams, type ShaderMountProps } from '../shader-mount';
-import {
-  getShaderColorFromString,
-  warpFragmentShader,
-  type WarpUniforms,
-  type PatternShape,
-  PatternShapes,
-} from '@paper-design/shaders';
+import { getShaderColorFromString, warpFragmentShader, type PatternShape, PatternShapes } from '@paper-design/shaders';
 
 export type WarpParams = {
   scale?: number;
@@ -227,7 +221,7 @@ export const presetFilteredLight: WarpPreset = {
     swirl: 0,
     swirlIterations: 0,
     shapeScale: 0,
-    shape: PatternShapes.Stripes
+    shape: PatternShapes.Stripes,
   },
 };
 
@@ -247,11 +241,9 @@ export const presetKelp: WarpPreset = {
     swirl: 0.15,
     swirlIterations: 0,
     shapeScale: 0.74,
-    shape: PatternShapes.Stripes
+    shape: PatternShapes.Stripes,
   },
 };
-
-
 
 export const warpPresets: WarpPreset[] = [
   defaultPreset,
@@ -268,7 +260,7 @@ export const warpPresets: WarpPreset[] = [
 ];
 
 export const Warp = (props: WarpProps): JSX.Element => {
-  const uniforms: WarpUniforms = useMemo(() => {
+  const uniforms = useMemo(() => {
     return {
       u_scale: props.scale ?? defaultPreset.params.scale,
       u_rotation: props.rotation ?? defaultPreset.params.rotation,

--- a/packages/shaders-react/src/shaders/waves.tsx
+++ b/packages/shaders-react/src/shaders/waves.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { ShaderMount, type ShaderMountProps } from '../shader-mount';
-import { getShaderColorFromString, wavesFragmentShader, type WavesUniforms } from '@paper-design/shaders';
+import { getShaderColorFromString, wavesFragmentShader } from '@paper-design/shaders';
 
 export type WavesParams = {
   scale?: number;
@@ -129,7 +129,7 @@ export const wavesPresets: WavesPreset[] = [
 ];
 
 export const Waves = (props: WavesProps): JSX.Element => {
-  const uniforms: WavesUniforms = useMemo(() => {
+  const uniforms = useMemo(() => {
     return {
       u_scale: props.scale ?? defaultPreset.params.scale,
       u_rotation: props.rotation ?? defaultPreset.params.rotation,

--- a/packages/shaders/src/index.ts
+++ b/packages/shaders/src/index.ts
@@ -2,55 +2,55 @@
 export { ShaderMount } from './shader-mount';
 
 // ----- Grain clouds ----- //
-export { grainCloudsFragmentShader, type GrainCloudsUniforms } from './shaders/grain-clouds';
+export { grainCloudsFragmentShader } from './shaders/grain-clouds';
 
 // ----- Mesh gradient ----- //
 /** A shader that renders a mesh gradient with a rotating noise pattern and several layers of fractal noise */
-export { meshGradientFragmentShader, type MeshGradientUniforms } from './shaders/mesh-gradient';
+export { meshGradientFragmentShader } from './shaders/mesh-gradient';
 
 // ----- Smoke ring ----- //
 /** Fractional Brownian motion (fBm) noise over the polar coordinates, masked with ring shape */
-export { smokeRingFragmentShader, type SmokeRingUniforms } from './shaders/smoke-ring';
+export { smokeRingFragmentShader } from './shaders/smoke-ring';
 
 // ----- Neuro noise ----- //
 /** A shader rendering a fractal-like structure made of several layers of since-arches */
-export { neuroNoiseFragmentShader, type NeuroNoiseUniforms } from './shaders/neuro-noise';
+export { neuroNoiseFragmentShader } from './shaders/neuro-noise';
 
 // ----- Animated dots pattern: orbit type of animation ----- //
 /** A shader rendering an animated dots pattern based on Voronoi diagram */
-export { dotsOrbitFragmentShader, type DotsOrbitUniforms } from './shaders/dots-orbit';
+export { dotsOrbitFragmentShader } from './shaders/dots-orbit';
 
 // ----- Dot Grid ----- //
 /** A shader rendering a static dots pattern */
-export { dotsGridFragmentShader, DotsGridShapes, type DotsGridShape, type DotsGridUniforms } from './shaders/dots-grid';
+export { dotsGridFragmentShader, DotsGridShapes, type DotsGridShape } from './shaders/dots-grid';
 
 // ----- Stepped simplex noise ----- //
 /** A shader that calculates a combination of 2 simplex noises with result rendered as a stepped gradient */
-export { steppedSimplexNoiseFragmentShader, type SteppedSimplexNoiseUniforms } from './shaders/stepped-simplex-noise';
+export { steppedSimplexNoiseFragmentShader } from './shaders/stepped-simplex-noise';
 
 // ----- Metaballs ----- //
 /** A number of circlular shapes blened in a gooey way */
-export { metaballsFragmentShader, type MetaballsUniforms } from './shaders/metaballs';
+export { metaballsFragmentShader } from './shaders/metaballs';
 
 // ----- Perlin noise ----- //
 /** 2d noise with max number of parameters to be exposed to users */
-export { perlinNoiseFragmentShader, type PerlinNoiseUniforms } from './shaders/perlin-noise';
+export { perlinNoiseFragmentShader } from './shaders/perlin-noise';
 
 // ----- Voronoi Diagram ----- //
 /** Voronoi diagram: classic + rounded edges */
-export { voronoiFragmentShader, type VoronoiUniforms } from './shaders/voronoi';
+export { voronoiFragmentShader } from './shaders/voronoi';
 
 // ----- Waves ----- //
 /** Waves pattern */
-export { wavesFragmentShader, type WavesUniforms } from './shaders/waves';
+export { wavesFragmentShader } from './shaders/waves';
 
 // ----- Warping Distortion ----- //
 /** Warp: distortion + swirl + underlying shapes */
-export { warpFragmentShader, PatternShapes, type PatternShape, type WarpUniforms } from './shaders/warp';
+export { warpFragmentShader, PatternShapes, type PatternShape } from './shaders/warp';
 
 // ----- God Rays Effect ----- //
 /** Radial shape made of randomized stripes */
-export { godRaysFragmentShader, type GodRaysUniforms } from './shaders/god-rays';
+export { godRaysFragmentShader } from './shaders/god-rays';
 
 // ----- Uniform conversion utils ----- //
 export { getShaderColorFromString } from './get-shader-color-from-string';

--- a/packages/shaders/src/shaders/dots-grid.ts
+++ b/packages/shaders/src/shaders/dots-grid.ts
@@ -7,19 +7,6 @@ export const DotsGridShapes = {
 } as const;
 export type DotsGridShape = (typeof DotsGridShapes)[keyof typeof DotsGridShapes];
 
-export type DotsGridUniforms = {
-  u_colorBack: [number, number, number, number];
-  u_colorFill: [number, number, number, number];
-  u_colorStroke: [number, number, number, number];
-  u_dotSize: number;
-  u_gridSpacingX: number;
-  u_gridSpacingY: number;
-  u_strokeWidth: number;
-  u_sizeRange: number;
-  u_opacityRange: number;
-  u_shape: DotsGridShape;
-};
-
 /**
  * Dot Grid Pattern
  * (the size parameters are set in pixels)

--- a/packages/shaders/src/shaders/dots-orbit.ts
+++ b/packages/shaders/src/shaders/dots-orbit.ts
@@ -1,14 +1,3 @@
-export type DotsOrbitUniforms = {
-  u_scale: number;
-  u_color1: [number, number, number, number];
-  u_color2: [number, number, number, number];
-  u_color3: [number, number, number, number];
-  u_color4: [number, number, number, number];
-  u_dotSize: number;
-  u_dotSizeRange: number;
-  u_spreading: number;
-};
-
 /**
  * Dots Pattern with dots moving around their grid position
  * The artwork by Ksenia Kondrashova

--- a/packages/shaders/src/shaders/god-rays.ts
+++ b/packages/shaders/src/shaders/god-rays.ts
@@ -1,18 +1,3 @@
-export type GodRaysUniforms = {
-  u_offsetX: number;
-  u_offsetY: number;
-  u_colorBack: [number, number, number, number];
-  u_color1: [number, number, number, number];
-  u_color2: [number, number, number, number];
-  u_color3: [number, number, number, number];
-  u_spotty: number;
-  u_midSize: number;
-  u_midIntensity: number;
-  u_frequency: number;
-  u_density: number;
-  u_blending: number;
-};
-
 /**
  * GodRays pattern
  * The artwork by Ksenia Kondrashova

--- a/packages/shaders/src/shaders/grain-clouds.ts
+++ b/packages/shaders/src/shaders/grain-clouds.ts
@@ -1,10 +1,3 @@
-export type GrainCloudsUniforms = {
-  u_scale: number;
-  u_color1: [number, number, number, number];
-  u_color2: [number, number, number, number];
-  u_grainAmount: number;
-};
-
 /**
  * Renders a grainy texture over top of blobby animated clouds
  * This is an example shader that we're using to bootstrap the project

--- a/packages/shaders/src/shaders/mesh-gradient.ts
+++ b/packages/shaders/src/shaders/mesh-gradient.ts
@@ -1,10 +1,3 @@
-export type MeshGradientUniforms = {
-  u_color1: [number, number, number, number];
-  u_color2: [number, number, number, number];
-  u_color3: [number, number, number, number];
-  u_color4: [number, number, number, number];
-};
-
 /**
  * Mesh Gradient, based on https://www.shadertoy.com/view/wdyczG
  * Renders a mesh gradient with a rotating noise pattern

--- a/packages/shaders/src/shaders/metaballs.ts
+++ b/packages/shaders/src/shaders/metaballs.ts
@@ -1,12 +1,3 @@
-export type MetaballsUniforms = {
-  u_scale: number;
-  u_color1: [number, number, number, number];
-  u_color2: [number, number, number, number];
-  u_color3: [number, number, number, number];
-  u_ballSize: number;
-  u_visibilityRange: number;
-};
-
 /**
  * Metaballs (circular shapes with gooey effect applied)
  * The artwork by Ksenia Kondrashova

--- a/packages/shaders/src/shaders/neuro-noise.ts
+++ b/packages/shaders/src/shaders/neuro-noise.ts
@@ -1,10 +1,3 @@
-export type NeuroNoiseUniforms = {
-  u_scale: number;
-  u_colorFront: [number, number, number, number];
-  u_colorBack: [number, number, number, number];
-  u_brightness: number;
-};
-
 /**
  * Neuro Noise Pattern
  * The original artwork: https://codepen.io/ksenia-k/full/vYwgrWv by Ksenia Kondrashova

--- a/packages/shaders/src/shaders/perlin-noise.ts
+++ b/packages/shaders/src/shaders/perlin-noise.ts
@@ -1,14 +1,3 @@
-export type PerlinNoiseUniforms = {
-  u_scale: number;
-  u_color1: [number, number, number, number];
-  u_color2: [number, number, number, number];
-  u_proportion: number;
-  u_contour: number;
-  u_octaveCount: number;
-  u_persistence: number;
-  u_lacunarity: number;
-};
-
 /**
  * 3d Perlin noise with exposed parameters
  * Based on https://www.shadertoy.com/view/NlSGDz

--- a/packages/shaders/src/shaders/smoke-ring.ts
+++ b/packages/shaders/src/shaders/smoke-ring.ts
@@ -1,12 +1,3 @@
-export type SmokeRingUniforms = {
-  u_scale: number;
-  u_colorBack: [number, number, number, number];
-  u_colorInner: [number, number, number, number];
-  u_colorOuter: [number, number, number, number];
-  u_noiseScale: number;
-  u_thickness: number;
-};
-
 /**
  * Smoke Ring by Ksenia Kondrashova
  * Renders a fractional Brownian motion (fBm) noise over the

--- a/packages/shaders/src/shaders/stepped-simplex-noise.ts
+++ b/packages/shaders/src/shaders/stepped-simplex-noise.ts
@@ -1,13 +1,3 @@
-export type SteppedSimplexNoiseUniforms = {
-  u_scale: number;
-  u_color1: [number, number, number, number];
-  u_color2: [number, number, number, number];
-  u_color3: [number, number, number, number];
-  u_color4: [number, number, number, number];
-  u_color5: [number, number, number, number];
-  u_steps_number: number;
-};
-
 /**
  * Stepped Simplex Noise by Ksenia Kondrashova
  * Calculates a combination of 2 simplex noises with result rendered as

--- a/packages/shaders/src/shaders/voronoi.ts
+++ b/packages/shaders/src/shaders/voronoi.ts
@@ -1,18 +1,3 @@
-export type VoronoiUniforms = {
-  u_scale: number;
-  u_colorCell1: [number, number, number, number];
-  u_colorCell2: [number, number, number, number];
-  u_colorCell3: [number, number, number, number];
-  u_colorEdges: [number, number, number, number];
-  u_colorMid: [number, number, number, number];
-  u_colorGradient: number;
-  u_distance: number;
-  u_edgesSize: number;
-  u_edgesSharpness: number;
-  u_middleSize: number;
-  u_middleSharpness: number;
-};
-
 /**
  * Voronoi pattern
  * The artwork by Ksenia Kondrashova

--- a/packages/shaders/src/shaders/warp.ts
+++ b/packages/shaders/src/shaders/warp.ts
@@ -5,21 +5,6 @@ export const PatternShapes = {
 } as const;
 export type PatternShape = (typeof PatternShapes)[keyof typeof PatternShapes];
 
-export type WarpUniforms = {
-  u_scale: number;
-  u_rotation: number;
-  u_color1: [number, number, number, number];
-  u_color2: [number, number, number, number];
-  u_color3: [number, number, number, number];
-  u_proportion: number;
-  u_softness: number;
-  u_shape: PatternShape;
-  u_shapeScale: number;
-  u_distortion: number;
-  u_swirl: number;
-  u_swirlIterations: number;
-};
-
 /**
  * 3d Perlin noise with exposed parameters
  *

--- a/packages/shaders/src/shaders/waves.ts
+++ b/packages/shaders/src/shaders/waves.ts
@@ -1,16 +1,3 @@
-export type WavesUniforms = {
-  u_scale: number;
-  u_rotation: number;
-  u_color1: [number, number, number, number];
-  u_color2: [number, number, number, number];
-  u_shape: number;
-  u_frequency: number;
-  u_amplitude: number;
-  u_spacing: number;
-  u_dutyCycle: number;
-  u_edgeBlur: number;
-};
-
 /**
  * Stepped Simplex Noise by Ksenia Kondrashova
  * Calculates a combination of 2 simplex noises with result rendered as a stepped gradient


### PR DESCRIPTION
I've realized that the `type` we define for each shader's list of uniforms doesn't actually affect the app. If I add a new uniform to the type, it doesn't appear anywhere. And if I remove an existing one from the type, the app still works correctly. This makes sense since the list of uniforms is gathered directly from the GLSL code [here](https://github.com/paper-design/shaders/blob/4e4c1df927349749c7b0a3d717a5d37a0e1b4175/packages/shaders/src/shader-mount.ts#L79) but maybe we need it somehow still? 