### PR TITLE
Images as uniforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,8 +90,6 @@ const shaderParams = {
 };
 
 const meshGradient = new ShaderMount(myCanvas, meshGradientFragmentShader, shaderParams, undefined, 0.25);
-
-meshGradient.setUniforms(shaderParams);
 ```
 
 ## Roadmap:
@@ -122,7 +120,6 @@ meshGradient.setUniforms(shaderParams);
 1. Bump the version numbers as desired manually
 2. Use `bun run build` on the top level of the monorepo to build each package
 3. Use `bun run publish-all` to publish all (or `bun run publish-all-test` to do a dry run). You can do this even if you just bumped one package version. The others will fail to publish and continue.
-
 
 ## License and use
 

--- a/docs/src/app/texture-test/layout.tsx
+++ b/docs/src/app/texture-test/layout.tsx
@@ -1,0 +1,9 @@
+import { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Texture Test | Paper',
+};
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/docs/src/app/texture-test/page.tsx
+++ b/docs/src/app/texture-test/page.tsx
@@ -17,32 +17,13 @@ uniform vec2 u_resolution;
 out vec4 fragColor;
 
 void main() {
-    vec2 rawCoord = gl_FragCoord.xy;
-    if (u_resolution.x == 0.0 || u_resolution.y == 0.0) {
-        fragColor = vec4(1.0, 0.0, 0.0, 1.0);
-        return;
-    }
+    vec2 st = gl_FragCoord.xy / u_resolution;
 
-    vec2 st = rawCoord / u_resolution;
-    if (any(isnan(st)) || any(isinf(st))) {
-        fragColor = vec4(0.0, 0.0, 1.0, 1.0);
-        return;
-    }
+    // Flip the y coordinate (1.0 - y) to match typical texture coordinates
+    st.y = 1.0 - st.y;
 
-    // Sample the texture using the calculated UV coordinates
-    vec4 texColor = texture(u_texture, st);
-
-    // Mix the texture color with our debug values
-    fragColor = mix(
-        texColor,
-        vec4(
-            rawCoord.x / 1000.0,
-            rawCoord.y / 1000.0,
-            u_resolution.x / 1000.0,
-            1.0
-        ),
-        0.5
-    );
+    // Simply output the texture color
+    fragColor = texture(u_texture, st);
 }`;
 
 const TextureTest = () => {

--- a/docs/src/app/texture-test/page.tsx
+++ b/docs/src/app/texture-test/page.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import Link from 'next/link';
+import { BackButton } from '@/components/back-button';
+import { ShaderMount } from '@paper-design/shaders-react';
+import { useState, useEffect } from 'react';
+
+// Just a quick hard coded test to make sure passing textures is working
+// and to be an example for building out more shaders that accept textures
+
+const fragmentShader = `#version 300 es
+precision highp float;
+
+uniform sampler2D u_texture;
+uniform vec2 u_resolution;
+
+out vec4 fragColor;
+
+void main() {
+  vec2 st = gl_FragCoord.xy / u_resolution;
+  st.y = 1.0 - st.y;
+  vec4 color = texture(u_texture, st);
+  fragColor = color;
+}
+`;
+
+const TextureTest = () => {
+  const [image, setImage] = useState<HTMLImageElement | null>(null);
+
+  useEffect(() => {
+    const img = new Image();
+    img.src = '/logo-placeholder.webp';
+    img.onload = () => {
+      setImage(img);
+    };
+  }, []);
+
+  if (image === null) {
+    return null;
+  }
+
+  return (
+    <>
+      <Link href="/">
+        <BackButton />
+      </Link>
+
+      <ShaderMount
+        fragmentShader={fragmentShader}
+        uniforms={{ u_texture: image }}
+        style={{ position: 'fixed', width: 300, aspectRatio: '1/1' }}
+      />
+    </>
+  );
+};
+
+export default TextureTest;

--- a/docs/src/app/texture-test/page.tsx
+++ b/docs/src/app/texture-test/page.tsx
@@ -21,6 +21,7 @@ void main() {
   st.y = 1.0 - st.y;
   vec4 color = texture(u_texture, st);
   fragColor = color;
+  fragColor = vec4(st, 0.0, 1.0);
 }
 `;
 

--- a/docs/src/app/texture-test/page.tsx
+++ b/docs/src/app/texture-test/page.tsx
@@ -17,13 +17,29 @@ uniform vec2 u_resolution;
 out vec4 fragColor;
 
 void main() {
-  vec2 st = gl_FragCoord.xy / u_resolution;
-  st.y = 1.0 - st.y;
-  vec4 color = texture(u_texture, st);
-  fragColor = color;
-  fragColor = vec4(st, 0.0, 1.0);
-}
-`;
+    // Log raw values first
+    vec2 rawCoord = gl_FragCoord.xy;
+    // If resolution is 0, this will output red
+    if (u_resolution.x == 0.0 || u_resolution.y == 0.0) {
+        fragColor = vec4(1.0, 0.0, 0.0, 1.0);
+        return;
+    }
+
+    vec2 st = rawCoord / u_resolution;
+    // If st calculation results in NaN or Inf, output blue
+    if (any(isnan(st)) || any(isinf(st))) {
+        fragColor = vec4(0.0, 0.0, 1.0, 1.0);
+        return;
+    }
+
+    // Output debugging values
+    fragColor = vec4(
+        rawCoord.x / 1000.0, // R channel: x coordinate scaled down
+        rawCoord.y / 1000.0, // G channel: y coordinate scaled down
+        u_resolution.x / 1000.0, // B channel: resolution x scaled down
+        1.0
+    );
+}`;
 
 const TextureTest = () => {
   const [image, setImage] = useState<HTMLImageElement | null>(null);

--- a/docs/src/app/texture-test/page.tsx
+++ b/docs/src/app/texture-test/page.tsx
@@ -17,27 +17,31 @@ uniform vec2 u_resolution;
 out vec4 fragColor;
 
 void main() {
-    // Log raw values first
     vec2 rawCoord = gl_FragCoord.xy;
-    // If resolution is 0, this will output red
     if (u_resolution.x == 0.0 || u_resolution.y == 0.0) {
         fragColor = vec4(1.0, 0.0, 0.0, 1.0);
         return;
     }
 
     vec2 st = rawCoord / u_resolution;
-    // If st calculation results in NaN or Inf, output blue
     if (any(isnan(st)) || any(isinf(st))) {
         fragColor = vec4(0.0, 0.0, 1.0, 1.0);
         return;
     }
 
-    // Output debugging values
-    fragColor = vec4(
-        rawCoord.x / 1000.0, // R channel: x coordinate scaled down
-        rawCoord.y / 1000.0, // G channel: y coordinate scaled down
-        u_resolution.x / 1000.0, // B channel: resolution x scaled down
-        1.0
+    // Sample the texture using the calculated UV coordinates
+    vec4 texColor = texture(u_texture, st);
+
+    // Mix the texture color with our debug values
+    fragColor = mix(
+        texColor,
+        vec4(
+            rawCoord.x / 1000.0,
+            rawCoord.y / 1000.0,
+            u_resolution.x / 1000.0,
+            1.0
+        ),
+        0.5
     );
 }`;
 

--- a/docs/src/app/texture-test/page.tsx
+++ b/docs/src/app/texture-test/page.tsx
@@ -18,24 +18,43 @@ uniform vec2 u_resolution;
 out vec4 fragColor;
 
 vec2 get_img_uv(vec2 uv, float canvas_ratio, float img_ratio) {
+
+  bool is_cover = true;
+  bool is_centered = true;
+  float scale_factor = 1.;
+
   vec2 img_uv = uv;
   img_uv.y = 1. - img_uv.y;
-  img_uv -= .5;
-  if (canvas_ratio > img_ratio) {
-    img_uv.x = img_uv.x * canvas_ratio / img_ratio;
-  } else {
-    img_uv.y = img_uv.y * img_ratio / canvas_ratio;
+  
+  if (is_centered) {
+    img_uv -= .5;  
   }
-  float scale_factor = 1.;
-  scale_factor += 2. * 1e-2;
+  
+  if (is_cover) {
+    if (canvas_ratio > img_ratio) {
+      img_uv.y *= (img_ratio / canvas_ratio);
+    } else {
+      img_uv.x *= (canvas_ratio / img_ratio);
+    }
+  } else {
+    // fit canvas    
+    if (canvas_ratio > img_ratio) {
+      img_uv.x = img_uv.x * canvas_ratio / img_ratio;
+    } else {
+      img_uv.y = img_uv.y * img_ratio / canvas_ratio;
+    }
+  }
+  
   img_uv /= scale_factor;
-  img_uv += .5;
+  if (is_centered) {
+    img_uv += .5;  
+  }
 
   return img_uv;
 }
 
 float get_uv_frame(vec2 uv) {
-  return step(1e-2, uv.x) * step(uv.x, 1. - 1e-2) * step(1e-2, uv.y) * step(uv.y, 1. - 1e-2);
+  return step(1e-3, uv.x) * step(uv.x, 1. - 1e-3) * step(1e-3, uv.y) * step(uv.y, 1. - 1e-3);
 }
 
 void main() {

--- a/docs/src/app/texture-test/page.tsx
+++ b/docs/src/app/texture-test/page.tsx
@@ -45,10 +45,18 @@ const TextureTest = () => {
         <BackButton />
       </Link>
 
+      {/* Testing with passing URL */}
+      <ShaderMount
+        fragmentShader={fragmentShader}
+        uniforms={{ u_texture: '/logo-placeholder.webp' }}
+        style={{ width: 300, aspectRatio: '1/1' }}
+      />
+
+      {/* Testing with passing image */}
       <ShaderMount
         fragmentShader={fragmentShader}
         uniforms={{ u_texture: image }}
-        style={{ position: 'fixed', width: 300, aspectRatio: '1/1' }}
+        style={{ width: 300, aspectRatio: '1/1' }}
       />
     </>
   );

--- a/docs/src/app/texture-test/page.tsx
+++ b/docs/src/app/texture-test/page.tsx
@@ -66,14 +66,14 @@ const TextureTest = () => {
       <ShaderMount
         fragmentShader={fragmentShader}
         uniforms={{ u_texture: '/logo-placeholder.webp' }}
-        style={{ width: 300, aspectRatio: '1/1' }}
+        style={{ width: 300, height: 300, aspectRatio: '1/1' }}
       />
 
       {/* Testing with passing image */}
       <ShaderMount
         fragmentShader={fragmentShader}
         uniforms={{ u_texture: image }}
-        style={{ width: 300, aspectRatio: '1/1' }}
+        style={{ width: 300, height: 300, aspectRatio: '1/1' }}
       />
     </>
   );

--- a/docs/src/app/texture-test/page.tsx
+++ b/docs/src/app/texture-test/page.tsx
@@ -12,18 +12,49 @@ const fragmentShader = `#version 300 es
 precision highp float;
 
 uniform sampler2D u_texture;
+uniform float u_texture_aspect_ratio;
 uniform vec2 u_resolution;
 
 out vec4 fragColor;
 
 void main() {
+    // Get normalized coordinates
     vec2 st = gl_FragCoord.xy / u_resolution;
 
-    // Flip the y coordinate (1.0 - y) to match typical texture coordinates
-    st.y = 1.0 - st.y;
+    // Calculate the aspect ratio of the canvas
+    float canvasAspectRatio = u_resolution.x / u_resolution.y;
 
-    // Simply output the texture color
-    fragColor = texture(u_texture, st);
+    // Adjust texture coordinates to maintain aspect ratio
+    vec2 adjustedSt = st;
+
+    // Center the texture (move origin to center)
+    adjustedSt = adjustedSt * 2.0 - 1.0;
+
+    // Scale based on aspect ratios to prevent distortion
+    if (u_texture_aspect_ratio > canvasAspectRatio) {
+        // Texture is wider than canvas (relative to height)
+        // Scale x to fit within canvas width
+        adjustedSt.x *= canvasAspectRatio / u_texture_aspect_ratio;
+    } else {
+        // Texture is taller than canvas (relative to width)
+        // Scale y to fit within canvas height
+        adjustedSt.y *= u_texture_aspect_ratio / canvasAspectRatio;
+    }
+
+    // Convert back to 0-1 range
+    adjustedSt = adjustedSt * 0.5 + 0.5;
+
+    // Flip the y coordinate to match typical texture coordinates
+    adjustedSt.y = 1.0 - adjustedSt.y;
+
+    // Check if we're outside the valid texture coordinates
+    if (adjustedSt.x < 0.0 || adjustedSt.x > 1.0 || adjustedSt.y < 0.0 || adjustedSt.y > 1.0) {
+        // Outside the texture bounds - show transparent or a background color
+        fragColor = vec4(0.1, 0.1, 0.1, 1.0); // Dark gray background
+    } else {
+        // Sample the texture with our adjusted coordinates
+        fragColor = texture(u_texture, adjustedSt);
+    }
 }`;
 
 const TextureTest = () => {
@@ -47,19 +78,43 @@ const TextureTest = () => {
         <BackButton />
       </Link>
 
-      {/* Testing with passing URL */}
-      <ShaderMount
-        fragmentShader={fragmentShader}
-        uniforms={{ u_texture: '/logo-placeholder.webp' }}
-        style={{ width: 300, height: 300, aspectRatio: '1/1' }}
-      />
+      <h1>Texture Aspect Ratio Test</h1>
+      <p>
+        These examples demonstrate how the shader maintains the texture&apos;s aspect ratio regardless of container
+        shape.
+      </p>
 
-      {/* Testing with passing image */}
-      <ShaderMount
-        fragmentShader={fragmentShader}
-        uniforms={{ u_texture: image }}
-        style={{ width: 300, height: 300, aspectRatio: '1/1' }}
-      />
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '20px' }}>
+        {/* Square container */}
+        <div>
+          <h2>Square Container with URL (1:1)</h2>
+          <ShaderMount
+            fragmentShader={fragmentShader}
+            uniforms={{ u_texture: '/logo-placeholder.webp' }}
+            style={{ width: 300, height: 300, border: '1px solid #ccc' }}
+          />
+        </div>
+
+        {/* Wide container */}
+        <div>
+          <h2>Wide Container with Image in Memory (2:1)</h2>
+          <ShaderMount
+            fragmentShader={fragmentShader}
+            uniforms={{ u_texture: image }}
+            style={{ width: 400, height: 200, border: '1px solid #ccc' }}
+          />
+        </div>
+
+        {/* Tall container */}
+        <div>
+          <h2>Tall Container with Image in Memory (1:2)</h2>
+          <ShaderMount
+            fragmentShader={fragmentShader}
+            uniforms={{ u_texture: image }}
+            style={{ width: 200, height: 400, border: '1px solid #ccc' }}
+          />
+        </div>
+      </div>
     </>
   );
 };

--- a/docs/src/home-shaders.ts
+++ b/docs/src/home-shaders.ts
@@ -37,6 +37,7 @@ import {
   spiralPresets,
 } from '@paper-design/shaders-react';
 import { StaticImageData } from 'next/image';
+import TextureTest from './app/texture-test/page';
 
 type HomeShaderConfig = {
   name: string;
@@ -47,6 +48,12 @@ type HomeShaderConfig = {
 };
 
 export const homeShaders = [
+  {
+    name: 'texture test',
+    url: '/texture-test',
+    ShaderComponent: TextureTest,
+    shaderConfig: {},
+  },
   {
     name: 'simplex noise',
     image: simplexNoiseImg,

--- a/packages/shaders-react/src/shader-mount.tsx
+++ b/packages/shaders-react/src/shader-mount.tsx
@@ -95,6 +95,8 @@ export const ShaderMount: React.FC<ShaderMountProps> = ({
   useEffect(() => {
     const initShader = async () => {
       if (canvasRef.current) {
+        console.log('initializing shader');
+        console.log(uniforms);
         const processedUniforms = await processUniforms(uniforms);
         shaderMountRef.current = new ShaderMountVanilla(
           canvasRef.current,

--- a/packages/shaders-react/src/shader-mount.tsx
+++ b/packages/shaders-react/src/shader-mount.tsx
@@ -1,11 +1,11 @@
 import React, { useEffect, useRef } from 'react';
-import { ShaderMount as ShaderMountVanilla } from '@paper-design/shaders';
+import { ShaderMount as ShaderMountVanilla, type ShaderMountUniforms } from '@paper-design/shaders';
 
 export interface ShaderMountProps {
   ref?: React.RefObject<HTMLCanvasElement>;
   fragmentShader: string;
   style?: React.CSSProperties;
-  uniforms?: Record<string, number | number[]>;
+  uniforms?: ShaderMountUniforms;
   webGlContextAttributes?: WebGLContextAttributes;
   speed?: number;
   seed?: number;

--- a/packages/shaders-react/src/shader-mount.tsx
+++ b/packages/shaders-react/src/shader-mount.tsx
@@ -95,8 +95,6 @@ export const ShaderMount: React.FC<ShaderMountProps> = ({
   useEffect(() => {
     const initShader = async () => {
       if (canvasRef.current) {
-        console.log('initializing shader');
-        console.log(uniforms);
         const processedUniforms = await processUniforms(uniforms);
         shaderMountRef.current = new ShaderMountVanilla(
           canvasRef.current,

--- a/packages/shaders-react/src/shader-mount.tsx
+++ b/packages/shaders-react/src/shader-mount.tsx
@@ -96,7 +96,6 @@ export const ShaderMount: React.FC<ShaderMountProps> = ({
     const initShader = async () => {
       if (canvasRef.current) {
         const processedUniforms = await processUniforms(uniforms);
-        console.log(processedUniforms);
         shaderMountRef.current = new ShaderMountVanilla(
           canvasRef.current,
           fragmentShader,

--- a/packages/shaders-react/src/shader-mount.tsx
+++ b/packages/shaders-react/src/shader-mount.tsx
@@ -1,11 +1,14 @@
 import React, { useEffect, useRef } from 'react';
 import { ShaderMount as ShaderMountVanilla, type ShaderMountUniforms } from '@paper-design/shaders';
 
+/** The React ShaderMount can also accept strings as uniform values, which will assumed to be URLs and loaded as images */
+export type ShaderMountUniformsReact = { [key: string]: ShaderMountUniforms[keyof ShaderMountUniforms] | string };
+
 export interface ShaderMountProps {
   ref?: React.RefObject<HTMLCanvasElement>;
   fragmentShader: string;
   style?: React.CSSProperties;
-  uniforms?: ShaderMountUniforms;
+  uniforms?: ShaderMountUniformsReact;
   webGlContextAttributes?: WebGLContextAttributes;
   speed?: number;
   seed?: number;
@@ -14,6 +17,39 @@ export interface ShaderMountProps {
 /** Params that every shader can set as part of their controls */
 export type GlobalParams = Pick<ShaderMountProps, 'speed' | 'seed'>;
 
+/** Parse the provided uniforms, turning URL strings into loaded images */
+const processUniforms = (uniforms: ShaderMountUniformsReact): Promise<ShaderMountUniforms> => {
+  const processedUniforms: ShaderMountUniforms = {};
+  const imageLoadPromises: Promise<void>[] = [];
+
+  Object.entries(uniforms).forEach(([key, value]) => {
+    if (typeof value === 'string') {
+      const imagePromise = new Promise<void>((resolve, reject) => {
+        const img = new Image();
+        img.crossOrigin = 'anonymous';
+        img.onload = () => {
+          processedUniforms[key] = img;
+          resolve();
+        };
+        img.onerror = () => {
+          console.error(`Could not set uniforms. Failed to load image at ${value}`);
+          reject();
+        };
+        img.src = value;
+      });
+      imageLoadPromises.push(imagePromise);
+    } else {
+      processedUniforms[key] = value;
+    }
+  });
+
+  return Promise.all(imageLoadPromises).then(() => processedUniforms);
+};
+
+/**
+ * A React component that mounts a shader and updates its uniforms as the component's props change
+ * If you pass a string as a uniform value, it will be assumed to be a URL and attempted to be loaded as an image
+ */
 export const ShaderMount: React.FC<ShaderMountProps> = ({
   ref,
   fragmentShader,
@@ -27,16 +63,21 @@ export const ShaderMount: React.FC<ShaderMountProps> = ({
   const shaderMountRef = useRef<ShaderMountVanilla | null>(null);
 
   useEffect(() => {
-    if (canvasRef.current) {
-      shaderMountRef.current = new ShaderMountVanilla(
-        canvasRef.current,
-        fragmentShader,
-        uniforms,
-        webGlContextAttributes,
-        speed,
-        seed
-      );
-    }
+    const initShader = async () => {
+      if (canvasRef.current) {
+        const processedUniforms = await processUniforms(uniforms);
+        shaderMountRef.current = new ShaderMountVanilla(
+          canvasRef.current,
+          fragmentShader,
+          processedUniforms,
+          webGlContextAttributes,
+          speed,
+          seed
+        );
+      }
+    };
+
+    initShader();
 
     return () => {
       shaderMountRef.current?.dispose();
@@ -44,7 +85,12 @@ export const ShaderMount: React.FC<ShaderMountProps> = ({
   }, [fragmentShader, webGlContextAttributes]);
 
   useEffect(() => {
-    shaderMountRef.current?.setUniforms(uniforms);
+    const updateUniforms = async () => {
+      const processedUniforms = await processUniforms(uniforms);
+      shaderMountRef.current?.setUniforms(processedUniforms);
+    };
+
+    updateUniforms();
   }, [uniforms]);
 
   useEffect(() => {

--- a/packages/shaders-react/src/shader-mount.tsx
+++ b/packages/shaders-react/src/shader-mount.tsx
@@ -96,6 +96,7 @@ export const ShaderMount: React.FC<ShaderMountProps> = ({
     const initShader = async () => {
       if (canvasRef.current) {
         const processedUniforms = await processUniforms(uniforms);
+        console.log(processedUniforms);
         shaderMountRef.current = new ShaderMountVanilla(
           canvasRef.current,
           fragmentShader,

--- a/packages/shaders/README.md
+++ b/packages/shaders/README.md
@@ -24,6 +24,4 @@ const meshGradient = new ShaderMount(
   meshGradientFragmentShader,
   shaderParams
 );
-
-meshGradient.setUniforms(shaderParams);
 ```

--- a/packages/shaders/src/index.ts
+++ b/packages/shaders/src/index.ts
@@ -1,5 +1,5 @@
 /** The core Shader Mounting class. Pass it a canvas element and a fragment shader to get started. */
-export { ShaderMount } from './shader-mount';
+export { ShaderMount, type ShaderMountUniforms } from './shader-mount';
 
 // ----- Grain clouds ----- //
 export { grainCloudsFragmentShader, type GrainCloudsUniforms } from './shaders/grain-clouds';

--- a/packages/shaders/src/shader-mount.ts
+++ b/packages/shaders/src/shader-mount.ts
@@ -155,7 +155,7 @@ export class ShaderMount {
 
   /** Creates a texture from an image and sets it into a uniform value */
   private setTextureUniform = (uniformName: string, image: HTMLImageElement): void => {
-    if (!image.complete) {
+    if (!image.complete || image.naturalWidth === 0) {
       throw new Error(`Image for uniform ${uniformName} must be fully loaded`);
     }
 

--- a/packages/shaders/src/shader-mount.ts
+++ b/packages/shaders/src/shader-mount.ts
@@ -54,6 +54,7 @@ export class ShaderMount {
     this.setupUniforms();
     // Put the user provided values into the uniforms
     this.setUniformValues(this.providedUniforms);
+    console.log('provided uniforms', this.providedUniforms);
 
     // Set the animation speed after everything is ready to go
     this.setSpeed(speed);

--- a/packages/shaders/src/shader-mount.ts
+++ b/packages/shaders/src/shader-mount.ts
@@ -101,6 +101,8 @@ export class ShaderMount {
   private handleResize = () => {
     const newWidth = this.canvas.clientWidth;
     const newHeight = this.canvas.clientHeight;
+    console.log('new width', newWidth);
+    console.log('new height', newHeight);
 
     if (this.canvas.width !== newWidth || this.canvas.height !== newHeight) {
       this.canvas.width = newWidth;

--- a/packages/shaders/src/shader-mount.ts
+++ b/packages/shaders/src/shader-mount.ts
@@ -88,6 +88,7 @@ export class ShaderMount {
         Object.keys(this.providedUniforms).map((key) => [key, this.gl.getUniformLocation(this.program!, key)])
       ),
     };
+    console.log('uniform locations', this.uniformLocations);
   };
 
   private resizeObserver: ResizeObserver | null = null;
@@ -207,41 +208,44 @@ export class ShaderMount {
     this.gl.useProgram(this.program);
     Object.entries(updatedUniforms).forEach(([key, value]) => {
       const location = this.uniformLocations[key];
-      if (location) {
-        if (value instanceof HTMLImageElement) {
-          // Texture case, requires a good amount of code so it gets its own function:
-          console.log('calling setTextureUniform');
-          this.setTextureUniform(key, value);
-        } else if (Array.isArray(value)) {
-          // Array case, supports 2, 3, 4, 9, 16 length arrays
-          switch (value.length) {
-            case 2:
-              this.gl.uniform2fv(location, value);
-              break;
-            case 3:
-              this.gl.uniform3fv(location, value);
-              break;
-            case 4:
-              this.gl.uniform4fv(location, value);
-              break;
-            default:
-              if (value.length === 9) {
-                this.gl.uniformMatrix3fv(location, false, value);
-              } else if (value.length === 16) {
-                this.gl.uniformMatrix4fv(location, false, value);
-              } else {
-                console.warn(`Unsupported uniform array length: ${value.length}`);
-              }
-          }
-        } else if (typeof value === 'number') {
-          // Number case, supports floats and ints
-          this.gl.uniform1f(location, value);
-        } else if (typeof value === 'boolean') {
-          // Boolean case, supports true and false
-          this.gl.uniform1i(location, value ? 1 : 0);
-        } else {
-          console.warn(`Unsupported uniform type for ${key}: ${typeof value}`);
+      if (!location) {
+        console.warn(`Uniform location for ${key} not found`);
+        return;
+      }
+
+      if (value instanceof HTMLImageElement) {
+        // Texture case, requires a good amount of code so it gets its own function:
+        console.log('calling setTextureUniform');
+        this.setTextureUniform(key, value);
+      } else if (Array.isArray(value)) {
+        // Array case, supports 2, 3, 4, 9, 16 length arrays
+        switch (value.length) {
+          case 2:
+            this.gl.uniform2fv(location, value);
+            break;
+          case 3:
+            this.gl.uniform3fv(location, value);
+            break;
+          case 4:
+            this.gl.uniform4fv(location, value);
+            break;
+          default:
+            if (value.length === 9) {
+              this.gl.uniformMatrix3fv(location, false, value);
+            } else if (value.length === 16) {
+              this.gl.uniformMatrix4fv(location, false, value);
+            } else {
+              console.warn(`Unsupported uniform array length: ${value.length}`);
+            }
         }
+      } else if (typeof value === 'number') {
+        // Number case, supports floats and ints
+        this.gl.uniform1f(location, value);
+      } else if (typeof value === 'boolean') {
+        // Boolean case, supports true and false
+        this.gl.uniform1i(location, value ? 1 : 0);
+      } else {
+        console.warn(`Unsupported uniform type for ${key}: ${typeof value}`);
       }
     });
   };

--- a/packages/shaders/src/shader-mount.ts
+++ b/packages/shaders/src/shader-mount.ts
@@ -132,6 +132,7 @@ export class ShaderMount {
     // If the resolution has changed, we need to update the uniform
     if (this.resolutionChanged) {
       this.gl.uniform2f(this.uniformLocations.u_resolution!, this.gl.canvas.width, this.gl.canvas.height);
+      console.log('setting resolution to: ' + this.gl.canvas.width + ' ' + this.gl.canvas.height);
       this.gl.uniform1f(this.uniformLocations.u_pixelRatio!, window.devicePixelRatio);
       this.resolutionChanged = false;
     }

--- a/packages/shaders/src/shader-mount.ts
+++ b/packages/shaders/src/shader-mount.ts
@@ -112,6 +112,8 @@ export class ShaderMount {
   private render = (currentTime: number) => {
     if (this.hasBeenDisposed) return;
 
+    console.log('rendering');
+
     // Calculate the delta time
     const dt = currentTime - this.lastFrameTime;
     this.lastFrameTime = currentTime;

--- a/packages/shaders/src/shader-mount.ts
+++ b/packages/shaders/src/shader-mount.ts
@@ -177,9 +177,9 @@ export class ShaderMount {
 
     // Upload image to texture
     this.gl.texImage2D(this.gl.TEXTURE_2D, 0, this.gl.RGBA, this.gl.RGBA, this.gl.UNSIGNED_BYTE, image);
-
-    if (texture === null) {
-      console.error('Failed to create texture, will not be passed as a uniform');
+    const error = this.gl.getError();
+    if (error !== this.gl.NO_ERROR || texture === null) {
+      console.error('WebGL error when uploading texture:', error);
       return;
     }
 

--- a/packages/shaders/src/shader-mount.ts
+++ b/packages/shaders/src/shader-mount.ts
@@ -132,7 +132,6 @@ export class ShaderMount {
     // If the resolution has changed, we need to update the uniform
     if (this.resolutionChanged) {
       this.gl.uniform2f(this.uniformLocations.u_resolution!, this.gl.canvas.width, this.gl.canvas.height);
-      console.log('setting resolution to: ' + this.gl.canvas.width + ' ' + this.gl.canvas.height);
       this.gl.uniform1f(this.uniformLocations.u_pixelRatio!, window.devicePixelRatio);
       this.resolutionChanged = false;
     }
@@ -210,6 +209,7 @@ export class ShaderMount {
       if (location) {
         if (value instanceof HTMLImageElement) {
           // Texture case, requires a good amount of code so it gets its own function:
+          console.log('calling setTextureUniform');
           this.setTextureUniform(key, value);
         } else if (Array.isArray(value)) {
           // Array case, supports 2, 3, 4, 9, 16 length arrays

--- a/packages/shaders/src/shader-mount.ts
+++ b/packages/shaders/src/shader-mount.ts
@@ -112,8 +112,6 @@ export class ShaderMount {
   private render = (currentTime: number) => {
     if (this.hasBeenDisposed) return;
 
-    console.log('rendering');
-
     // Calculate the delta time
     const dt = currentTime - this.lastFrameTime;
     this.lastFrameTime = currentTime;
@@ -188,6 +186,9 @@ export class ShaderMount {
 
     // Store the texture
     this.textures.set(uniformName, texture);
+
+    console.log('setting texture');
+    console.log(texture);
 
     // Set up texture unit and uniform
     const location = this.uniformLocations[uniformName];

--- a/packages/shaders/src/shader-mount.ts
+++ b/packages/shaders/src/shader-mount.ts
@@ -101,14 +101,14 @@ export class ShaderMount {
   private handleResize = () => {
     const newWidth = this.canvas.clientWidth;
     const newHeight = this.canvas.clientHeight;
-    console.log('new width', newWidth);
-    console.log('new height', newHeight);
 
     if (this.canvas.width !== newWidth || this.canvas.height !== newHeight) {
       this.canvas.width = newWidth;
       this.canvas.height = newHeight;
       this.resolutionChanged = true;
       this.gl.viewport(0, 0, this.gl.canvas.width, this.gl.canvas.height);
+      console.log('setting resolution changed to true');
+      console.log(this.canvas.width, this.gl.canvas.width);
       this.render(performance.now()); // this is necessary to avoid flashes while resizing (the next scheduled render will set uniforms)
     }
   };

--- a/packages/shaders/src/shader-mount.ts
+++ b/packages/shaders/src/shader-mount.ts
@@ -138,6 +138,11 @@ export class ShaderMount {
 
     this.gl.drawArrays(this.gl.TRIANGLES, 0, 6);
 
+    const error = this.gl.getError();
+    if (error !== this.gl.NO_ERROR) {
+      console.error('WebGL error during render:', error);
+    }
+
     // Loop if we're animating
     if (this.speed !== 0) {
       this.requestRender();
@@ -155,33 +160,48 @@ export class ShaderMount {
 
   /** Creates a texture from an image and sets it into a uniform value */
   private setTextureUniform = (uniformName: string, image: HTMLImageElement): void => {
+    console.log(`Starting setTextureUniform for ${uniformName}`);
+
     if (!image.complete) {
-      throw new Error(`Image for uniform ${uniformName} must be fully loaded`);
+      console.error(`Image for uniform ${uniformName} not fully loaded`);
+      return;
     }
 
     // Clean up existing texture if present
     const existingTexture = this.textures.get(uniformName);
     if (existingTexture) {
+      console.log(`Cleaning up existing texture for ${uniformName}`);
       this.gl.deleteTexture(existingTexture);
     }
 
     // Create and set up the new texture
     const texture = this.gl.createTexture();
+    if (!texture) {
+      console.error(`Failed to create texture for ${uniformName}`);
+      return;
+    }
+    console.log(`Created new texture for ${uniformName}`);
+
     this.gl.bindTexture(this.gl.TEXTURE_2D, texture);
 
-    // Set texture parameters
+    // Log WebGL state before texture upload
+    console.log(`Current WebGL program: ${this.gl.getParameter(this.gl.CURRENT_PROGRAM)}`);
+    console.log(`Bound texture: ${this.gl.getParameter(this.gl.TEXTURE_BINDING_2D)}`);
+
+    // Upload image to texture with error checking
+    this.gl.texImage2D(this.gl.TEXTURE_2D, 0, this.gl.RGBA, this.gl.RGBA, this.gl.UNSIGNED_BYTE, image);
+    const error = this.gl.getError();
+    if (error !== this.gl.NO_ERROR) {
+      console.error(`WebGL error when uploading texture ${uniformName}:`, error);
+      return;
+    }
+    console.log(`Successfully uploaded texture data for ${uniformName}`);
+
+    // Set up texture parameters
     this.gl.texParameteri(this.gl.TEXTURE_2D, this.gl.TEXTURE_WRAP_S, this.gl.CLAMP_TO_EDGE);
     this.gl.texParameteri(this.gl.TEXTURE_2D, this.gl.TEXTURE_WRAP_T, this.gl.CLAMP_TO_EDGE);
     this.gl.texParameteri(this.gl.TEXTURE_2D, this.gl.TEXTURE_MIN_FILTER, this.gl.LINEAR);
     this.gl.texParameteri(this.gl.TEXTURE_2D, this.gl.TEXTURE_MAG_FILTER, this.gl.LINEAR);
-
-    // Upload image to texture
-    this.gl.texImage2D(this.gl.TEXTURE_2D, 0, this.gl.RGBA, this.gl.RGBA, this.gl.UNSIGNED_BYTE, image);
-    const error = this.gl.getError();
-    if (error !== this.gl.NO_ERROR || texture === null) {
-      console.error('WebGL error when uploading texture:', error);
-      return;
-    }
 
     // Store the texture
     this.textures.set(uniformName, texture);
@@ -189,12 +209,14 @@ export class ShaderMount {
     // Set up texture unit and uniform
     const location = this.uniformLocations[uniformName];
     if (location) {
-      // Use texture unit based on the order textures were added
       const textureUnit = this.textures.size - 1;
+      console.log(`Using texture unit ${textureUnit} for ${uniformName}`);
       this.gl.useProgram(this.program);
       this.gl.activeTexture(this.gl.TEXTURE0 + textureUnit);
       this.gl.bindTexture(this.gl.TEXTURE_2D, texture);
       this.gl.uniform1i(location, textureUnit);
+    } else {
+      console.warn(`No uniform location found for ${uniformName}`);
     }
   };
 


### PR DESCRIPTION
`bun run dev` and then:
http://localhost:3000/texture-test

`/docs/app/texture-test` to see how to use it


Also removes the need to use `setupUniforms` immediately after ShaderMount in the vanilla version.