### PR TITLE
Colors array can be any length

### DIFF
--- a/docs/src/app/gradient-demo-css/layout.tsx
+++ b/docs/src/app/gradient-demo-css/layout.tsx
@@ -1,0 +1,9 @@
+import { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Paper',
+};
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/docs/src/app/gradient-demo-css/page.tsx
+++ b/docs/src/app/gradient-demo-css/page.tsx
@@ -1,0 +1,301 @@
+'use client';
+
+import { useControls, button, folder } from 'leva';
+import { setParamsSafe, useResetLevaParams } from '@/helpers/use-reset-leva-params';
+import { usePresetHighlight } from '@/helpers/use-preset-highlight';
+import { cleanUpLevaParams } from '@/helpers/clean-up-leva-params';
+import Link from 'next/link';
+import { BackButton } from '@/components/back-button';
+import { memo } from 'react';
+import { getShaderColorFromString, type ShaderPreset } from '@paper-design/shaders';
+import { ShaderMount, ShaderComponentProps } from '@paper-design/shaders-react';
+
+type vec4 = [number, number, number, number];
+const gradientDemoCSSMaxColorCount = 7;
+
+type GradientDemoCSSUniforms = {
+  u_colors: vec4[];
+  u_colors_count: number;
+  u_test: number;
+};
+
+type GradientDemoCSSParams = {
+  colors?: string[];
+  test?: number;
+};
+
+/**
+ *
+ * Uniforms include:
+ * u_colors: An array of colors, each color is an array of 4 numbers [r, g, b, a]
+ * u_colors_count: The number of colors in the u_colors array
+ */
+
+const gradientDemoCSSFragmentShader: string = `#version 300 es
+precision highp float;
+
+uniform float u_pixelRatio;
+uniform vec2 u_resolution;
+uniform float u_time;
+
+uniform float u_test;
+uniform vec4 u_colors[${gradientDemoCSSMaxColorCount}];
+uniform float u_colors_count;
+
+out vec4 fragColor;
+
+#define TWO_PI 6.28318530718
+#define PI 3.14159265358979323846
+
+// magic numbers (and magic could be better tbh)
+#define OKLCH_CHROMA_THRESHOLD .001
+#define OKLCH_HUE_NEUTRALIZER -2.
+
+vec3 srgbToLinear(vec3 srgb) {
+    return pow(srgb, vec3(2.2));
+}
+
+vec3 linearToSrgb(vec3 linear) {
+    return pow(linear, vec3(1.0/2.2));
+}
+
+vec3 LrgbToOklab(vec3 rgb) {
+    float L = pow(0.4122214708 * rgb.r + 0.5363325363 * rgb.g + 0.0514459929 * rgb.b, 1.0 / 3.0);
+    float M = pow(0.2119034982 * rgb.r + 0.6806995451 * rgb.g + 0.1073969566 * rgb.b, 1.0 / 3.0);
+    float S = pow(0.0883024619 * rgb.r + 0.2817188376 * rgb.g + 0.6299787005 * rgb.b, 1.0 / 3.0);
+    return vec3(
+        0.2104542553 * L + 0.793617785 * M - 0.0040720468 * S,
+        1.9779984951 * L - 2.428592205 * M + 0.4505937099 * S,
+        0.0259040371 * L + 0.7827717662 * M - 0.808675766 * S
+    );
+}
+
+vec3 OklabToLrgb(vec3 oklab) {
+    float L = oklab.x;
+    float a = oklab.y;
+    float b = oklab.z;
+
+    float l_ = L + 0.3963377774 * a + 0.2158037573 * b;
+    float m_ = L - 0.1055613458 * a - 0.0638541728 * b;
+    float s_ = L - 0.0894841775 * a - 1.291485548 * b;
+
+    float l = l_ * l_ * l_;
+    float m = m_ * m_ * m_;
+    float s = s_ * s_ * s_;
+
+    return vec3(
+        4.0767416621 * l - 3.3077115913 * m + 0.2309699292 * s,
+        -1.2684380046 * l + 2.6097574011 * m - 0.3413193965 * s,
+        -0.0041960863 * l - 0.7034186147 * m + 1.707614701 * s
+    );
+}
+
+vec3 oklabToOklch(vec3 oklab) {
+    float C = length(oklab.yz);
+    float H = atan(oklab.z, oklab.y);
+    if (C < OKLCH_CHROMA_THRESHOLD) {
+      H = OKLCH_HUE_NEUTRALIZER;
+    }
+    return vec3(oklab.x, C, H);
+}
+
+vec3 oklchToOklab(vec3 oklch) {
+    float a = oklch.y * cos(oklch.z);
+    float b = oklch.y * sin(oklch.z);
+    return vec3(oklch.x, a, b);
+}
+
+float mixHue(float h1, float h2, float mixer) {
+    float delta = mod(h2 - h1 + PI, TWO_PI) - PI;
+    return h1 + mixer * delta;
+}
+
+void main() {
+    vec2 uv = gl_FragCoord.xy / u_resolution.xy;
+    float mixer = uv.x * (u_colors_count - 1.);
+    vec3 color = vec3(0.);
+
+    if (u_test == 0.) {
+        vec3 gradient = u_colors[0].rgb;
+        for (int i = 1; i < ${gradientDemoCSSMaxColorCount}; i++) {
+            if (i >= int(u_colors_count)) break;
+            float localMixer = clamp(mixer - float(i - 1), 0., 1.);
+            gradient = mix(gradient, u_colors[i].rgb, localMixer);
+        }
+        color = gradient;
+    } else {
+        vec3 gradient = oklabToOklch(LrgbToOklab(srgbToLinear(u_colors[0].rgb)));
+        for (int i = 1; i < ${gradientDemoCSSMaxColorCount}; i++) {
+            if (i >= int(u_colors_count)) break;
+            float localMixer = clamp(mixer - float(i - 1), 0., 1.);
+            vec3 c = oklabToOklch(LrgbToOklab(srgbToLinear(u_colors[i].rgb)));
+            gradient.x = mix(gradient.x, c.x, localMixer);
+            gradient.y = mix(gradient.y, c.y, localMixer);
+            if (gradient.y > OKLCH_CHROMA_THRESHOLD && c.y > OKLCH_CHROMA_THRESHOLD) {
+                gradient.z = mixHue(gradient.z, c.z, localMixer);
+            }
+        }
+        color = linearToSrgb(OklabToLrgb(oklchToOklab(gradient)));
+    }
+
+    fragColor = vec4(color, 1.);
+}
+`;
+
+interface GradientDemoCSSProps extends ShaderComponentProps, GradientDemoCSSParams {}
+type GradientDemoCSSPreset = ShaderPreset<GradientDemoCSSParams>;
+
+const defaultPreset: GradientDemoCSSPreset = {
+  name: 'Default',
+  params: {
+    test: 1,
+    colors: [
+      'hsla(0, 100%, 50%, 1)',
+      'hsla(240, 100%, 50%, 1)',
+      'hsla(72, 76%, 20%, 1)',
+      'hsla(259, 29%, 73%, 1)',
+      'hsla(263, 57%, 39%, 1)',
+      'hsla(48, 73%, 84%, 1)',
+      'hsla(295, 32%, 70%, 1)',
+    ],
+  },
+};
+
+const beachPreset: GradientDemoCSSPreset = {
+  name: 'Beach',
+  params: {
+    test: 1,
+    colors: ['#999999', '#0000ff'],
+  },
+};
+
+const fadedPreset: GradientDemoCSSPreset = {
+  name: 'Faded',
+  params: {
+    test: 0,
+    colors: ['hsla(186, 41%, 90%, 1)', 'hsla(208, 71%, 85%, 1)', 'hsla(183, 51%, 92%, 1)', 'hsla(201, 72%, 90%, 1)'],
+  },
+};
+
+const gradientDemoCSSPresets: GradientDemoCSSPreset[] = [beachPreset, defaultPreset, fadedPreset];
+
+const GradientDemoCSS: React.FC<GradientDemoCSSProps> = memo(function GradientDemoCSSImpl({
+  colors = defaultPreset.params.colors,
+  test = defaultPreset.params.test,
+  ...props
+}: GradientDemoCSSProps) {
+  const uniforms: GradientDemoCSSUniforms = {
+    u_colors: colors.map(getShaderColorFromString),
+    u_colors_count: colors.length,
+    u_test: test ?? defaultPreset.params.test,
+  };
+
+  return <ShaderMount {...props} fragmentShader={gradientDemoCSSFragmentShader} uniforms={uniforms} />;
+});
+
+const defaults = gradientDemoCSSPresets[0].params;
+
+export default function Page() {
+  const [{ colorCount }, setColorCount] = useControls(() => ({
+    Colors: folder({
+      colorCount: {
+        value: defaults.colors.length,
+        min: 2,
+        max: gradientDemoCSSMaxColorCount,
+        step: 1,
+      },
+    }),
+  }));
+
+  const [levaColors, setLevaColors] = useControls(() => {
+    const colors: Record<string, { value: string }> = {};
+
+    for (let i = 0; i < colorCount; i++) {
+      colors[`color${i}`] = {
+        value: defaults.colors[i] ?? 'hsla(' + Math.random() * 360 + ', 50%, 50%, 1)',
+      };
+    }
+
+    return {
+      Colors: folder(colors),
+    };
+  }, [colorCount]);
+
+  const [params, setParams] = useControls(() => {
+    const presets: GradientDemoCSSParams = Object.fromEntries(
+      gradientDemoCSSPresets.map((preset) => {
+        return [
+          preset.name,
+          button(() => {
+            const { colors, ...presetParams } = preset.params;
+            setParamsSafe(params, setParams, presetParams);
+            setColorCount({ colorCount: colors.length });
+
+            const presetColors = Object.fromEntries(
+              colors.map((color, index) => {
+                return [`color${index}`, color];
+              })
+            );
+
+            setColorCount({ colorCount: colors.length });
+            setParamsSafe(levaColors, setLevaColors, presetColors);
+          }),
+        ];
+      })
+    );
+
+    return {
+      Parameters: folder(
+        {
+          test: { value: defaults.test, min: 0, max: 1, step: 1, order: 400 },
+        },
+        { order: 1 }
+      ),
+      Presets: folder(presets as Record<string, string>, { order: 2 }),
+    };
+  }, [colorCount]);
+
+  // Reset to defaults on mount, so that Leva doesn't show values from other
+  // shaders when navigating (if two shaders have a color1 param for example)
+  useResetLevaParams(params, setParams, defaults);
+  usePresetHighlight(gradientDemoCSSPresets, params);
+  cleanUpLevaParams(params);
+
+  const colors = Object.values(levaColors) as unknown as string[];
+
+  return (
+    <>
+      <Link href="/">
+        <BackButton />
+      </Link>
+      <div className="fixed flex size-full flex-col" style={{ width: 'calc(100% - 300px)' }}>
+        <div className="relative h-1/3">
+          <span className="absolute left-0 top-0 p-2 font-bold text-white">
+            {`CSS: linear-gradient(to right in oklch, ${colors.join(', ')})`}
+          </span>
+          <div
+            className="h-full"
+            style={{
+              background: `linear-gradient(to right in oklch, ${colors.join(', ')})`,
+            }}
+          />
+        </div>
+
+        <div className="relative h-1/3 w-full">
+          <div className="top-half absolute left-0 whitespace-pre p-2 font-bold text-white">Shader</div>
+          <GradientDemoCSS {...params} colors={colors} className="h-full w-full" />
+        </div>
+
+        <div className="relative h-1/3">
+          <span className="absolute left-0 top-0 p-2 font-bold text-white">{`CSS: linear-gradient(to right, ${colors.join(', ')})`}</span>
+          <div
+            className="h-full"
+            style={{
+              background: `linear-gradient(to right, ${colors.join(', ')})`,
+            }}
+          />
+        </div>
+      </div>
+    </>
+  );
+}

--- a/docs/src/app/gradient-demo-css/page.tsx
+++ b/docs/src/app/gradient-demo-css/page.tsx
@@ -9,6 +9,7 @@ import { BackButton } from '@/components/back-button';
 import { memo } from 'react';
 import { getShaderColorFromString, type ShaderPreset } from '@paper-design/shaders';
 import { ShaderMount, ShaderComponentProps } from '@paper-design/shaders-react';
+import { useColors } from '@/helpers/use-colors';
 
 type vec4 = [number, number, number, number];
 const gradientDemoCSSMaxColorCount = 7;
@@ -196,30 +197,10 @@ const GradientDemoCSS: React.FC<GradientDemoCSSProps> = memo(function GradientDe
 const defaults = gradientDemoCSSPresets[0].params;
 
 export default function Page() {
-  const [{ colorCount }, setColorCount] = useControls(() => ({
-    Colors: folder({
-      colorCount: {
-        value: defaults.colors.length,
-        min: 2,
-        max: gradientDemoCSSMaxColorCount,
-        step: 1,
-      },
-    }),
-  }));
-
-  const [levaColors, setLevaColors] = useControls(() => {
-    const colors: Record<string, { value: string }> = {};
-
-    for (let i = 0; i < colorCount; i++) {
-      colors[`color${i}`] = {
-        value: defaults.colors[i] ?? 'hsla(' + Math.random() * 360 + ', 50%, 50%, 1)',
-      };
-    }
-
-    return {
-      Colors: folder(colors),
-    };
-  }, [colorCount]);
+  const { colors, setColors } = useColors({
+    defaultColors: defaults.colors,
+    maxColorCount: gradientDemoCSSMaxColorCount,
+  });
 
   const [params, setParams] = useControls(() => {
     const presets: GradientDemoCSSParams = Object.fromEntries(
@@ -228,17 +209,8 @@ export default function Page() {
           preset.name,
           button(() => {
             const { colors, ...presetParams } = preset.params;
+            setColors(colors);
             setParamsSafe(params, setParams, presetParams);
-            setColorCount({ colorCount: colors.length });
-
-            const presetColors = Object.fromEntries(
-              colors.map((color, index) => {
-                return [`color${index}`, color];
-              })
-            );
-
-            setColorCount({ colorCount: colors.length });
-            setParamsSafe(levaColors, setLevaColors, presetColors);
           }),
         ];
       })
@@ -253,15 +225,13 @@ export default function Page() {
       ),
       Presets: folder(presets as Record<string, string>, { order: 2 }),
     };
-  }, [colorCount]);
+  }, [colors.length]);
 
   // Reset to defaults on mount, so that Leva doesn't show values from other
   // shaders when navigating (if two shaders have a color1 param for example)
   useResetLevaParams(params, setParams, defaults);
   usePresetHighlight(gradientDemoCSSPresets, params);
   cleanUpLevaParams(params);
-
-  const colors = Object.values(levaColors) as unknown as string[];
 
   return (
     <>

--- a/docs/src/app/gradient-demo-mixer/layout.tsx
+++ b/docs/src/app/gradient-demo-mixer/layout.tsx
@@ -1,0 +1,9 @@
+import { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Paper',
+};
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/docs/src/app/gradient-demo-mixer/page.tsx
+++ b/docs/src/app/gradient-demo-mixer/page.tsx
@@ -1,0 +1,315 @@
+'use client';
+
+import { useControls, button, folder } from 'leva';
+import { setParamsSafe, useResetLevaParams } from '@/helpers/use-reset-leva-params';
+import { usePresetHighlight } from '@/helpers/use-preset-highlight';
+import { cleanUpLevaParams } from '@/helpers/clean-up-leva-params';
+import Link from 'next/link';
+import { BackButton } from '@/components/back-button';
+
+import { memo } from 'react';
+import { ShaderMount, type ShaderComponentProps } from '@paper-design/shaders-react';
+import { getShaderColorFromString, type ShaderPreset } from '@paper-design/shaders';
+
+type vec4 = [number, number, number, number];
+const gradientDemoMixerMaxColorCount = 7;
+
+type GradientDemoMixerUniforms = {
+  u_colors: vec4[];
+  u_colors_count: number;
+  u_shape: number;
+  u_softness: number;
+  u_bNoise: number;
+  u_test: number;
+  u_extraSides: boolean;
+};
+
+type GradientDemoMixerParams = {
+  colors?: string[];
+  shape?: number;
+  softness?: number;
+  bNoise?: number;
+  test?: number;
+  extraSides?: boolean;
+};
+
+/**
+ *
+ * Uniforms include:
+ * u_colors: An array of colors, each color is an array of 4 numbers [r, g, b, a]
+ * u_colors_count: The number of colors in the u_colors array
+ */
+
+const gradientDemoMixerFragmentShader: string = `#version 300 es
+precision highp float;
+
+uniform float u_pixelRatio;
+uniform vec2 u_resolution;
+uniform float u_time;
+
+uniform float u_shape;
+uniform float u_softness;
+uniform float u_bNoise;
+uniform vec4 u_colors[${gradientDemoMixerMaxColorCount}];
+uniform float u_colors_count;
+uniform bool u_extraSides;
+uniform float u_test;
+
+out vec4 fragColor;
+
+
+float random(vec2 seed) {
+    return fract(sin(dot(seed, vec2(12.9898, 78.233))) * 43758.5453);
+}
+
+vec3 permute(vec3 x) { return mod(((x * 34.0) + 1.0) * x, 289.0); }
+float snoise(vec2 v) {
+  const vec4 C = vec4(0.211324865405187, 0.366025403784439,
+    -0.577350269189626, 0.024390243902439);
+  vec2 i = floor(v + dot(v, C.yy));
+  vec2 x0 = v - i + dot(i, C.xx);
+  vec2 i1;
+  i1 = (x0.x > x0.y) ? vec2(1.0, 0.0) : vec2(0.0, 1.0);
+  vec4 x12 = x0.xyxy + C.xxzz;
+  x12.xy -= i1;
+  i = mod(i, 289.0);
+  vec3 p = permute(permute(i.y + vec3(0.0, i1.y, 1.0))
+    + i.x + vec3(0.0, i1.x, 1.0));
+  vec3 m = max(0.5 - vec3(dot(x0, x0), dot(x12.xy, x12.xy),
+      dot(x12.zw, x12.zw)), 0.0);
+  m = m * m;
+  m = m * m;
+  vec3 x = 2.0 * fract(p * C.www) - 1.0;
+  vec3 h = abs(x) - 0.5;
+  vec3 ox = floor(x + 0.5);
+  vec3 a0 = x - ox;
+  m *= 1.79284291400159 - 0.85373472095314 * (a0 * a0 + h * h);
+  vec3 g;
+  g.x = a0.x * x0.x + h.x * x0.y;
+  g.yz = a0.yz * x12.xz + h.yz * x12.yw;
+  return 130.0 * dot(m, g);
+}
+
+float get_noise(vec2 uv, float t) {
+  float noise = .5 * snoise(uv - vec2(0., .3 * t));
+  noise += .5 * snoise(2. * uv + vec2(0., .32 * t));
+
+  return noise;
+}
+
+
+void main() {
+  vec2 uv = gl_FragCoord.xy / u_resolution.xy;
+  float ratio = u_resolution.x / u_resolution.y;
+
+  float noise = (sin(gl_FragCoord.x * 1.2 + sin(gl_FragCoord.y * 1.2)) * .5 + .5);
+
+  float shape = pow(uv.x, u_shape);
+//  float shape = pow(.5 + .5 * get_noise(uv, .4 * u_time), u_shape);
+
+
+  float mixer = shape * (u_colors_count - 1.);
+  if (u_extraSides == true) {
+    mixer = (shape - .5 / u_colors_count) * u_colors_count;
+  }
+
+  vec3 gradient = u_colors[0].rgb;
+
+  for (int i = 1; i < ${gradientDemoMixerMaxColorCount}; i++) {
+      if (i >= int(u_colors_count)) break;
+      float localT = clamp(mixer - float(i - 1), 0.0, 1.0);
+
+      if (u_test == 0.) {
+
+      } else if (u_test == 1.) {
+        localT = smoothstep(.5 - .5 * u_softness, .5 + .5 * u_softness, localT);
+      } else if (u_test == 2.) {
+        localT = 1. / (1. + exp(-1. / (pow(u_softness, 4.) + 1e-3) * (localT - .5)));
+      } else if (u_test == 3.) {
+        localT = smoothstep(0., 1., localT);
+        localT = 1. / (1. + exp(-1. / (pow(u_softness, 4.) + 1e-3) * (localT - .5)));
+      }
+
+      gradient = mix(gradient, u_colors[i].rgb, localT);
+  }
+
+  vec3 color = vec3(shape);
+  if (uv.y < .66) {
+   color = gradient;
+  }
+
+  color += 1. / 256. * u_bNoise * (random(.014 * gl_FragCoord.xy) - .5);
+
+  fragColor = vec4(color, 1.);
+}
+`;
+
+interface GradientDemoMixerProps extends ShaderComponentProps, GradientDemoMixerParams {}
+type GradientDemoMixerPreset = ShaderPreset<GradientDemoMixerParams>;
+
+const defaultPreset: GradientDemoMixerPreset = {
+  name: 'Default',
+  params: {
+    shape: 1,
+    softness: 0,
+    bNoise: 1,
+    test: 0,
+    extraSides: true,
+    colors: ['hsla(259, 29%, 73%, 1)', 'hsla(263, 57%, 39%, 1)', 'hsla(48, 73%, 84%, 1)', 'hsla(295, 32%, 70%, 1)'],
+  },
+};
+
+const bandingPreset: GradientDemoMixerPreset = {
+  name: 'banding',
+  params: {
+    shape: 0.67,
+    softness: 1,
+    bNoise: 0,
+    test: 1,
+    extraSides: true,
+    colors: ['#332848', '#094008'],
+  },
+};
+
+const gradientDemoMixerPresets: GradientDemoMixerPreset[] = [defaultPreset, bandingPreset];
+
+const GradientDemoMixer: React.FC<GradientDemoMixerProps> = memo(function GradientDemoMixerImpl({
+  bNoise = defaultPreset.params.bNoise,
+  colors = defaultPreset.params.colors,
+  extraSides = defaultPreset.params.extraSides,
+  shape = defaultPreset.params.shape,
+  softness = defaultPreset.params.softness,
+  test = defaultPreset.params.test,
+  ...props
+}: GradientDemoMixerProps) {
+  const uniforms: GradientDemoMixerUniforms = {
+    u_colors: colors.map(getShaderColorFromString),
+    u_colors_count: colors.length,
+    u_bNoise: bNoise ?? defaultPreset.params.bNoise,
+    u_extraSides: extraSides ?? defaultPreset.params.extraSides,
+    u_shape: shape ?? defaultPreset.params.shape,
+    u_softness: softness ?? defaultPreset.params.softness,
+    u_test: test ?? defaultPreset.params.test,
+  };
+
+  return <ShaderMount {...props} fragmentShader={gradientDemoMixerFragmentShader} uniforms={uniforms} />;
+});
+
+const defaults = gradientDemoMixerPresets[0].params;
+
+export default function Page() {
+  const [{ colorCount }, setColorCount] = useControls(() => ({
+    Colors: folder({
+      colorCount: {
+        value: defaults.colors.length,
+        min: 2,
+        max: gradientDemoMixerMaxColorCount,
+        step: 1,
+      },
+    }),
+  }));
+
+  const [levaColors, setLevaColors] = useControls(() => {
+    const colors: Record<string, { value: string }> = {};
+
+    for (let i = 0; i < colorCount; i++) {
+      colors[`color${i}`] = {
+        value: defaults.colors[i] ?? 'hsla(' + Math.random() * 360 + ', 50%, 50%, 1)',
+      };
+    }
+
+    return {
+      Colors: folder(colors),
+    };
+  }, [colorCount]);
+
+  const [params, setParams] = useControls(() => {
+    const presets: GradientDemoMixerParams = Object.fromEntries(
+      gradientDemoMixerPresets.map((preset) => {
+        return [
+          preset.name,
+          button(() => {
+            const { colors, ...presetParams } = preset.params;
+            setParamsSafe(params, setParams, presetParams);
+            setColorCount({ colorCount: colors.length });
+
+            const presetColors = Object.fromEntries(
+              colors.map((color, index) => {
+                return [`color${index}`, color];
+              })
+            );
+
+            setColorCount({ colorCount: colors.length });
+            setParamsSafe(levaColors, setLevaColors, presetColors);
+          }),
+        ];
+      })
+    );
+
+    return {
+      Parameters: folder(
+        {
+          shape: { value: defaults.shape, min: 0, max: 3, order: 5 },
+          extraSides: { value: defaults.extraSides, order: 1 },
+          test: { value: defaults.test, min: 0, max: 3, step: 1, order: 2 },
+          softness: { value: defaults.softness, min: 0, max: 1, order: 3 },
+          bNoise: { value: defaults.bNoise, min: 0, max: 100, order: 4 },
+        },
+        { order: 1 }
+      ),
+      Presets: folder(presets as Record<string, string>, { order: 2 }),
+    };
+  }, [colorCount]);
+
+  // Reset to defaults on mount, so that Leva doesn't show values from other
+  // shaders when navigating (if two shaders have a color1 param for example)
+  useResetLevaParams(params, setParams, defaults);
+  usePresetHighlight(gradientDemoMixerPresets, params);
+  cleanUpLevaParams(params);
+
+  const colors = Object.values(levaColors) as unknown as string[];
+
+  const getBlending = () => {
+    if (params.test == 0) {
+      return <>simple linear interpolation</>;
+    } else if (params.test == 1) {
+      return (
+        <>
+          smoothstep (use softness control)
+          <br />
+          https://thebookofshaders.com/glossary/?search=smoothstep
+        </>
+      );
+    } else if (params.test == 2) {
+      return (
+        <>
+          custom mixer (use softness control)
+          <br />
+          1. / (1. + exp(-1. / (pow(u_softness, 4.) + 1e-3) * (LINEAR_MIXER - .5)))
+        </>
+      );
+    } else if (params.test == 3) {
+      return (
+        <>
+          custom mixer (use softness control)
+          <br />
+          SMOOTH_MIXER = smoothstep(0., 1., LINEAR_MIXER);
+          <br />
+          RESULT = 1. / (1. + exp(-1. / (pow(u_softness, 4.) + 1e-3) * (SMOOTH_MIXER - .5)))
+        </>
+      );
+    }
+  };
+
+  return (
+    <>
+      <Link href="/">
+        <BackButton />
+      </Link>
+      <div className="relative flex size-full h-screen flex-col" style={{ width: 'calc(100% - 300px)' }}>
+        <div className="absolute left-0 top-1/3 whitespace-pre p-2 font-bold text-white">{getBlending()}</div>
+        <GradientDemoMixer {...params} colors={colors} className="h-full" />
+      </div>
+    </>
+  );
+}

--- a/docs/src/app/mesh-gradient/page.tsx
+++ b/docs/src/app/mesh-gradient/page.tsx
@@ -7,6 +7,8 @@ import { usePresetHighlight } from '@/helpers/use-preset-highlight';
 import { cleanUpLevaParams } from '@/helpers/clean-up-leva-params';
 import Link from 'next/link';
 import { BackButton } from '@/components/back-button';
+import { meshGradientMeta } from '@paper-design/shaders';
+import { useColors } from '@/helpers/use-colors';
 
 /**
  * You can copy/paste this example to use MeshGradient in your app
@@ -32,12 +34,23 @@ const MeshGradientExample = () => {
 const defaults = meshGradientPresets[0].params;
 
 const MeshGradientWithControls = () => {
+  // Colors: (1 / 3)
+  // const { colors, setColors } = useColors({
+  //   defaultColors: defaults.colors,
+  //   maxColorCount: meshGradientMeta.maxColorCount,
+  // });
+
   const [params, setParams] = useControls(() => {
     const presets = Object.fromEntries(
       // meshGradientPresets.map(({ name, params: { worldWidth, worldHeight, ...preset } }) => [
       meshGradientPresets.map(({ name, params: preset }) => [
         name,
-        button(() => setParamsSafe(params, setParams, preset)),
+        button(() => {
+          // Colors: (2 / 3)
+          // const { colors, ...presetParams } = preset;
+          // setColors(colors);
+          setParamsSafe(params, setParams, preset);
+        }),
       ])
     );
 
@@ -92,7 +105,12 @@ const MeshGradientWithControls = () => {
       <Link href="/">
         <BackButton />
       </Link>
-      <MeshGradient className="fixed size-full" {...params} />
+      <MeshGradient
+        {...params}
+        // Colors: (3 / 3)
+        // colors={colors}
+        className="fixed size-full"
+      />
     </>
   );
 };

--- a/docs/src/helpers/use-colors.ts
+++ b/docs/src/helpers/use-colors.ts
@@ -1,0 +1,49 @@
+import { folder, useControls } from 'leva';
+import { setParamsSafe } from './use-reset-leva-params';
+
+interface UseColorsArgs {
+  defaultColors: string[];
+  maxColorCount: number;
+}
+
+export function useColors({ defaultColors, maxColorCount }: UseColorsArgs) {
+  const [{ colorCount }, setColorCount] = useControls(() => ({
+    Colors: folder({
+      colorCount: {
+        value: defaultColors.length,
+        min: 2,
+        max: maxColorCount,
+        step: 1,
+      },
+    }),
+  }));
+
+  const [levaColors, setLevaColors] = useControls(() => {
+    const colors: Record<string, { value: string }> = {};
+
+    for (let i = 0; i < colorCount; i++) {
+      colors[`color${i + 1}`] = {
+        value: defaultColors[i] ?? 'hsla(' + Math.random() * 360 + ', 50%, 50%, 1)',
+      };
+    }
+
+    return {
+      Colors: folder(colors),
+    };
+  }, [colorCount]);
+
+  const setColors = (colors: string[]) => {
+    const presetColors = Object.fromEntries(
+      colors.map((color: string, index: number) => {
+        return [`color${index + 1}`, color];
+      })
+    );
+
+    setColorCount({ colorCount: colors.length });
+    setParamsSafe(levaColors, setLevaColors, presetColors);
+  };
+
+  const colors = Object.values(levaColors) as unknown as string[];
+
+  return { colors, setColors };
+}

--- a/packages/shaders-react/src/color-props-are-equal.ts
+++ b/packages/shaders-react/src/color-props-are-equal.ts
@@ -1,0 +1,37 @@
+interface PropsWithColors {
+  colors?: string[];
+  [key: string]: unknown;
+}
+
+export function colorPropsAreEqual(prevProps: PropsWithColors, nextProps: PropsWithColors): boolean {
+  for (const key in prevProps) {
+    if (key === 'colors') {
+      const prevIsArray = Array.isArray(prevProps.colors);
+      const nextIsArray = Array.isArray(nextProps.colors);
+
+      if (!prevIsArray || !nextIsArray) {
+        if (Object.is(prevProps.colors, nextProps.colors) === false) {
+          return false;
+        }
+
+        continue;
+      }
+
+      if (prevProps.colors?.length !== nextProps.colors?.length) {
+        return false;
+      }
+
+      if (!prevProps.colors?.every((color, index) => color === nextProps.colors?.[index])) {
+        return false;
+      }
+
+      continue;
+    }
+
+    if (Object.is(prevProps[key], nextProps[key]) === false) {
+      return false;
+    }
+  }
+
+  return true;
+}

--- a/packages/shaders-react/src/index.ts
+++ b/packages/shaders-react/src/index.ts
@@ -1,4 +1,5 @@
 export { ShaderMount } from './shader-mount';
+export type { ShaderMountProps, ShaderComponentProps } from './shader-mount';
 
 export { MeshGradient, meshGradientPresets } from './shaders/mesh-gradient';
 export type { MeshGradientProps } from './shaders/mesh-gradient';

--- a/packages/shaders-react/src/shader-mount.tsx
+++ b/packages/shaders-react/src/shader-mount.tsx
@@ -9,8 +9,8 @@ import {
 import { useMergeRefs } from './use-merge-refs';
 
 /** React Shader Mount can also accept strings as uniform values, which will assumed to be URLs and loaded as images */
-export interface ShaderMountUniformsReact {
-  [key: string]: string | number | number[] | HTMLImageElement;
+interface ShaderMountUniformsReact {
+  [key: string]: string | boolean | number | number[] | number[][] | HTMLImageElement;
 }
 
 export interface ShaderMountProps extends Omit<React.ComponentProps<'div'>, 'color'>, ShaderMotionParams {

--- a/packages/shaders-react/src/shaders/dot-grid.tsx
+++ b/packages/shaders-react/src/shaders/dot-grid.tsx
@@ -1,5 +1,6 @@
 import { memo } from 'react';
 import { ShaderMount, type ShaderComponentProps } from '../shader-mount';
+import { colorPropsAreEqual } from '../color-props-are-equal';
 import {
   getShaderColorFromString,
   dotGridFragmentShader,
@@ -211,7 +212,7 @@ export const DotGrid: React.FC<DotGridProps> = memo(function DotGridImpl({
   // Other props
   maxPixelCount = 6016 * 3384, // Higher max resolution for this shader
   ...props
-}) {
+}: DotGridProps) {
   const uniforms = {
     // Own uniforms
     u_colorBack: getShaderColorFromString(colorBack),
@@ -240,4 +241,4 @@ export const DotGrid: React.FC<DotGridProps> = memo(function DotGridImpl({
   return (
     <ShaderMount {...props} maxPixelCount={maxPixelCount} fragmentShader={dotGridFragmentShader} uniforms={uniforms} />
   );
-});
+}, colorPropsAreEqual);

--- a/packages/shaders-react/src/shaders/dot-orbit.tsx
+++ b/packages/shaders-react/src/shaders/dot-orbit.tsx
@@ -1,5 +1,6 @@
 import { memo } from 'react';
 import { ShaderMount, type ShaderComponentProps } from '../shader-mount';
+import { colorPropsAreEqual } from '../color-props-are-equal';
 import {
   getShaderColorFromString,
   dotOrbitFragmentShader,
@@ -59,7 +60,7 @@ export const DotOrbit: React.FC<DotOrbitProps> = memo(function DotOrbitImpl({
   worldWidth = defaultPreset.params.worldWidth,
   worldHeight = defaultPreset.params.worldHeight,
   ...props
-}) {
+}: DotOrbitProps) {
   const uniforms = {
     // Own uniforms
     u_color1: getShaderColorFromString(color1),
@@ -85,4 +86,4 @@ export const DotOrbit: React.FC<DotOrbitProps> = memo(function DotOrbitImpl({
   return (
     <ShaderMount {...props} speed={speed} frame={frame} fragmentShader={dotOrbitFragmentShader} uniforms={uniforms} />
   );
-});
+}, colorPropsAreEqual);

--- a/packages/shaders-react/src/shaders/god-rays.tsx
+++ b/packages/shaders-react/src/shaders/god-rays.tsx
@@ -1,5 +1,6 @@
 import { memo } from 'react';
 import { ShaderMount, type ShaderComponentProps } from '../shader-mount';
+import { colorPropsAreEqual } from '../color-props-are-equal';
 import {
   defaultObjectSizing,
   getShaderColorFromString,
@@ -156,7 +157,7 @@ export const GodRays: React.FC<GodRaysProps> = memo(function GodRaysImpl({
   worldWidth = defaultPreset.params.worldWidth,
   worldHeight = defaultPreset.params.worldHeight,
   ...props
-}) {
+}: GodRaysProps) {
   const uniforms = {
     // Own uniforms
     u_colorBack: getShaderColorFromString(colorBack),
@@ -185,4 +186,4 @@ export const GodRays: React.FC<GodRaysProps> = memo(function GodRaysImpl({
   return (
     <ShaderMount {...props} speed={speed} frame={frame} fragmentShader={godRaysFragmentShader} uniforms={uniforms} />
   );
-});
+}, colorPropsAreEqual);

--- a/packages/shaders-react/src/shaders/mesh-gradient.tsx
+++ b/packages/shaders-react/src/shaders/mesh-gradient.tsx
@@ -1,5 +1,6 @@
 import { memo } from 'react';
 import { ShaderMount, type ShaderComponentProps } from '../shader-mount';
+import { colorPropsAreEqual } from '../color-props-are-equal';
 import {
   defaultObjectSizing,
   getShaderColorFromString,
@@ -79,7 +80,7 @@ export const MeshGradient: React.FC<MeshGradientProps> = memo(function MeshGradi
   // worldWidth = defaultPreset.params.worldWidth,
   // worldHeight = defaultPreset.params.worldHeight,
   ...props
-}) {
+}: MeshGradientProps) {
   const uniforms = {
     // Own uniforms
     u_color1: getShaderColorFromString(color1),
@@ -108,4 +109,4 @@ export const MeshGradient: React.FC<MeshGradientProps> = memo(function MeshGradi
       uniforms={uniforms}
     />
   );
-});
+}, colorPropsAreEqual);

--- a/packages/shaders-react/src/shaders/metaballs.tsx
+++ b/packages/shaders-react/src/shaders/metaballs.tsx
@@ -1,5 +1,6 @@
 import { memo } from 'react';
 import { ShaderMount, type ShaderComponentProps } from '../shader-mount';
+import { colorPropsAreEqual } from '../color-props-are-equal';
 import {
   defaultObjectSizing,
   getShaderColorFromString,
@@ -56,7 +57,7 @@ export const Metaballs: React.FC<MetaballsProps> = memo(function MetaballsImpl({
   worldWidth = defaultPreset.params.worldWidth,
   worldHeight = defaultPreset.params.worldHeight,
   ...props
-}) {
+}: MetaballsProps) {
   const uniforms = {
     // Own uniforms
     u_color1: getShaderColorFromString(color1),
@@ -80,4 +81,4 @@ export const Metaballs: React.FC<MetaballsProps> = memo(function MetaballsImpl({
   return (
     <ShaderMount {...props} speed={speed} frame={frame} fragmentShader={metaballsFragmentShader} uniforms={uniforms} />
   );
-});
+}, colorPropsAreEqual);

--- a/packages/shaders-react/src/shaders/neuro-noise.tsx
+++ b/packages/shaders-react/src/shaders/neuro-noise.tsx
@@ -1,5 +1,6 @@
 import { memo } from 'react';
 import { ShaderMount, type ShaderComponentProps } from '../shader-mount';
+import { colorPropsAreEqual } from '../color-props-are-equal';
 import {
   defaultPatternSizing,
   getShaderColorFromString,
@@ -64,7 +65,7 @@ export const NeuroNoise: React.FC<NeuroNoiseProps> = memo(function NeuroNoiseImp
   worldWidth = defaultPreset.params.worldWidth,
   worldHeight = defaultPreset.params.worldHeight,
   ...props
-}) {
+}: NeuroNoiseProps) {
   const uniforms = {
     // Own uniforms
     u_colorFront: getShaderColorFromString(colorFront),
@@ -86,4 +87,4 @@ export const NeuroNoise: React.FC<NeuroNoiseProps> = memo(function NeuroNoiseImp
   return (
     <ShaderMount {...props} speed={speed} frame={frame} fragmentShader={neuroNoiseFragmentShader} uniforms={uniforms} />
   );
-});
+}, colorPropsAreEqual);

--- a/packages/shaders-react/src/shaders/perlin-noise.tsx
+++ b/packages/shaders-react/src/shaders/perlin-noise.tsx
@@ -1,5 +1,6 @@
 import { memo } from 'react';
 import { ShaderMount, type ShaderComponentProps } from '../shader-mount';
+import { colorPropsAreEqual } from '../color-props-are-equal';
 import {
   defaultPatternSizing,
   getShaderColorFromString,
@@ -151,7 +152,7 @@ export const PerlinNoise: React.FC<PerlinNoiseProps> = memo(function PerlinNoise
   offsetX = defaultPreset.params.offsetX,
   offsetY = defaultPreset.params.offsetY,
   ...props
-}) {
+}: PerlinNoiseProps) {
   const uniforms = {
     // Own uniforms
     u_color1: getShaderColorFromString(color1),
@@ -183,4 +184,4 @@ export const PerlinNoise: React.FC<PerlinNoiseProps> = memo(function PerlinNoise
       uniforms={uniforms}
     />
   );
-});
+}, colorPropsAreEqual);

--- a/packages/shaders-react/src/shaders/smoke-ring.tsx
+++ b/packages/shaders-react/src/shaders/smoke-ring.tsx
@@ -1,5 +1,6 @@
 import { memo } from 'react';
 import { ShaderMount, type ShaderComponentProps } from '../shader-mount';
+import { colorPropsAreEqual } from '../color-props-are-equal';
 import {
   defaultObjectSizing,
   getShaderColorFromString,
@@ -112,7 +113,7 @@ export const SmokeRing: React.FC<SmokeRingProps> = memo(function SmokeRingImpl({
   worldWidth = defaultPreset.params.worldWidth,
   worldHeight = defaultPreset.params.worldHeight,
   ...props
-}) {
+}: SmokeRingProps) {
   const uniforms = {
     // Own uniforms
     u_colorBack: getShaderColorFromString(colorBack),
@@ -139,4 +140,4 @@ export const SmokeRing: React.FC<SmokeRingProps> = memo(function SmokeRingImpl({
   return (
     <ShaderMount {...props} speed={speed} frame={frame} fragmentShader={smokeRingFragmentShader} uniforms={uniforms} />
   );
-});
+}, colorPropsAreEqual);

--- a/packages/shaders-react/src/shaders/spiral.tsx
+++ b/packages/shaders-react/src/shaders/spiral.tsx
@@ -1,5 +1,6 @@
 import { memo } from 'react';
 import { ShaderMount, type ShaderComponentProps } from '../shader-mount';
+import { colorPropsAreEqual } from '../color-props-are-equal';
 import {
   defaultPatternSizing,
   getShaderColorFromString,
@@ -192,7 +193,7 @@ export const Spiral: React.FC<SpiralProps> = memo(function SpiralImpl({
   worldWidth = defaultPreset.params.worldWidth,
   worldHeight = defaultPreset.params.worldHeight,
   ...props
-}) {
+}: SpiralProps) {
   const uniforms = {
     // Own uniforms
     u_color1: getShaderColorFromString(color1),
@@ -221,4 +222,4 @@ export const Spiral: React.FC<SpiralProps> = memo(function SpiralImpl({
   return (
     <ShaderMount {...props} speed={speed} frame={frame} fragmentShader={spiralFragmentShader} uniforms={uniforms} />
   );
-});
+}, colorPropsAreEqual);

--- a/packages/shaders-react/src/shaders/stepped-simplex-noise.tsx
+++ b/packages/shaders-react/src/shaders/stepped-simplex-noise.tsx
@@ -1,5 +1,6 @@
 import { memo } from 'react';
 import { ShaderMount, type ShaderComponentProps } from '../shader-mount';
+import { colorPropsAreEqual } from '../color-props-are-equal';
 import {
   getShaderColorFromString,
   steppedSimplexNoiseFragmentShader,
@@ -110,7 +111,7 @@ export const SteppedSimplexNoise: React.FC<SteppedSimplexNoiseProps> = memo(func
   worldWidth = defaultPreset.params.worldWidth,
   worldHeight = defaultPreset.params.worldHeight,
   ...props
-}) {
+}: SteppedSimplexNoiseProps) {
   const uniforms = {
     // Own uniforms
     u_color1: getShaderColorFromString(color1),
@@ -141,4 +142,4 @@ export const SteppedSimplexNoise: React.FC<SteppedSimplexNoiseProps> = memo(func
       uniforms={uniforms}
     />
   );
-});
+}, colorPropsAreEqual);

--- a/packages/shaders-react/src/shaders/voronoi.tsx
+++ b/packages/shaders-react/src/shaders/voronoi.tsx
@@ -1,5 +1,6 @@
-import { memo, useMemo } from 'react';
+import { memo } from 'react';
 import { ShaderMount, type ShaderComponentProps } from '../shader-mount';
+import { colorPropsAreEqual } from '../color-props-are-equal';
 import {
   defaultPatternSizing,
   getShaderColorFromString,
@@ -224,7 +225,7 @@ export const Voronoi: React.FC<VoronoiProps> = memo(function VoronoiImpl({
   worldWidth = defaultPreset.params.worldWidth,
   worldHeight = defaultPreset.params.worldHeight,
   ...props
-}) {
+}: VoronoiProps) {
   const uniforms = {
     // Own uniforms
     u_colorCell1: getShaderColorFromString(colorCell1),
@@ -254,4 +255,4 @@ export const Voronoi: React.FC<VoronoiProps> = memo(function VoronoiImpl({
   return (
     <ShaderMount {...props} speed={speed} frame={frame} fragmentShader={voronoiFragmentShader} uniforms={uniforms} />
   );
-});
+}, colorPropsAreEqual);

--- a/packages/shaders-react/src/shaders/warp.tsx
+++ b/packages/shaders-react/src/shaders/warp.tsx
@@ -1,5 +1,6 @@
 import { memo } from 'react';
 import { ShaderMount, type ShaderComponentProps } from '../shader-mount';
+import { colorPropsAreEqual } from '../color-props-are-equal';
 import {
   defaultPatternSizing,
   getShaderColorFromString,
@@ -289,7 +290,7 @@ export const Warp: React.FC<WarpProps> = memo(function WarpImpl({
   worldWidth = defaultPreset.params.worldWidth,
   worldHeight = defaultPreset.params.worldHeight,
   ...props
-}) {
+}: WarpProps) {
   const uniforms = {
     // Own uniforms
     u_color1: getShaderColorFromString(color1),
@@ -316,4 +317,4 @@ export const Warp: React.FC<WarpProps> = memo(function WarpImpl({
   } satisfies WarpUniforms;
 
   return <ShaderMount {...props} speed={speed} frame={frame} fragmentShader={warpFragmentShader} uniforms={uniforms} />;
-});
+}, colorPropsAreEqual);

--- a/packages/shaders-react/src/shaders/waves.tsx
+++ b/packages/shaders-react/src/shaders/waves.tsx
@@ -1,5 +1,6 @@
 import { memo } from 'react';
 import { ShaderMount, type ShaderComponentProps } from '../shader-mount';
+import { colorPropsAreEqual } from '../color-props-are-equal';
 import {
   defaultPatternSizing,
   getShaderColorFromString,
@@ -154,7 +155,7 @@ export const Waves: React.FC<WavesProps> = memo(function WavesImpl({
   // Other props
   maxPixelCount = 6016 * 3384, // Higher max resolution for this shader
   ...props
-}) {
+}: WavesProps) {
   const uniforms = {
     // Own uniforms
     u_color1: getShaderColorFromString(color1),
@@ -179,4 +180,4 @@ export const Waves: React.FC<WavesProps> = memo(function WavesImpl({
   } satisfies WavesUniforms;
 
   return <ShaderMount {...props} fragmentShader={wavesFragmentShader} uniforms={uniforms} />;
-});
+}, colorPropsAreEqual);

--- a/packages/shaders/src/index.ts
+++ b/packages/shaders/src/index.ts
@@ -16,6 +16,7 @@ export {
 /** A shader that renders a mesh gradient with a rotating noise pattern and several layers of fractal noise */
 export {
   meshGradientFragmentShader,
+  meshGradientMeta,
   type MeshGradientParams,
   type MeshGradientUniforms,
 } from './shaders/mesh-gradient';

--- a/packages/shaders/src/shader-color-spaces.ts
+++ b/packages/shaders/src/shader-color-spaces.ts
@@ -1,0 +1,6 @@
+export const ShaderColorSpaces = {
+  rgb: 0,
+  oklch: 1,
+} as const;
+
+export type ShaderColorSpace = keyof typeof ShaderColorSpaces;

--- a/packages/shaders/src/shaders/mesh-gradient.ts
+++ b/packages/shaders/src/shaders/mesh-gradient.ts
@@ -114,7 +114,7 @@ export const meshGradientMeta = {
   maxColorCount: 10,
 } as const;
 
-// export interface MeshGradientUniforms1 extends ShaderSizingUniforms {
+// export interface MeshGradientUniforms extends ShaderSizingUniforms {
 //   u_colors: vec4[];
 //   u_colorSpace: (typeof ShaderColorSpaces)[ShaderColorSpace];
 // }

--- a/packages/shaders/src/shaders/mesh-gradient.ts
+++ b/packages/shaders/src/shaders/mesh-gradient.ts
@@ -1,3 +1,4 @@
+import type { vec4 } from '../types';
 import type { ShaderMotionParams } from '../shader-mount';
 import type { ShaderSizingParams, ShaderSizingUniforms } from '../shader-sizing';
 
@@ -107,3 +108,15 @@ export interface MeshGradientParams extends ShaderMotionParams {
   color3?: string;
   color4?: string;
 }
+
+export const meshGradientMeta = {
+  maxColorCount: 10,
+} as const;
+
+// export interface MeshGradientUniforms extends ShaderSizingUniforms {
+//   u_colors: vec4[];
+// }
+
+// export interface MeshGradientParams extends ShaderSizingParams, ShaderMotionParams {
+//   colors?: string[];
+// }

--- a/packages/shaders/src/shaders/mesh-gradient.ts
+++ b/packages/shaders/src/shaders/mesh-gradient.ts
@@ -1,6 +1,7 @@
 import type { vec4 } from '../types';
 import type { ShaderMotionParams } from '../shader-mount';
-import type { ShaderSizingParams, ShaderSizingUniforms } from '../shader-sizing';
+import type { ShaderFit, ShaderSizingParams, ShaderSizingUniforms } from '../shader-sizing';
+import type { ShaderColorSpace, ShaderColorSpaces } from '../shader-color-spaces';
 
 /**
  * Mesh Gradient, based on https://www.shadertoy.com/view/wdyczG
@@ -113,10 +114,12 @@ export const meshGradientMeta = {
   maxColorCount: 10,
 } as const;
 
-// export interface MeshGradientUniforms extends ShaderSizingUniforms {
+// export interface MeshGradientUniforms1 extends ShaderSizingUniforms {
 //   u_colors: vec4[];
+//   u_colorSpace: (typeof ShaderColorSpaces)[ShaderColorSpace];
 // }
 
 // export interface MeshGradientParams extends ShaderSizingParams, ShaderMotionParams {
 //   colors?: string[];
+//   colorSpace?: ShaderColorSpace;
 // }

--- a/packages/shaders/src/shaders/metaballs.ts
+++ b/packages/shaders/src/shaders/metaballs.ts
@@ -6,6 +6,7 @@ import {
   type ShaderSizingUniforms,
 } from '../shader-sizing';
 import { declarePI, colorBandingFix } from '../shader-utils';
+
 /**
  * Metaballs (circular shapes with gooey effect applied)
  * The artwork by Ksenia Kondrashova
@@ -58,7 +59,7 @@ float get_ball_shape(vec2 uv, vec2 c, float p) {
 
 void main() {
   ${sizingSquareUV}
-  
+
   uv += .5;
 
   float t = u_time + 1.;

--- a/packages/shaders/src/types.ts
+++ b/packages/shaders/src/types.ts
@@ -1,0 +1,3 @@
+export type vec4 = [number, number, number, number];
+export type vec3 = [number, number, number];
+export type vec2 = [number, number];


### PR DESCRIPTION
- ShaderMount now supports arrays of arrays as uniforms (it will flatten them)
- React layer is responsible for passing extra "count" uniform for color arrays
- Shader GLSL files should export a "maximum count" 