### PR TITLE
Div wrapper for mounting

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ npm i @paper-design/shaders-react
 
 // vanilla
 npm i @paper-design/shaders
+
+// Please pin your dependency – we will ship breaking changes under 0.0.x versioning
 ```
 
 ### React example

--- a/README.md
+++ b/README.md
@@ -77,10 +77,10 @@ import { MeshGradient } from '@paper-design/shaders-react';
 ```js
 import { ShaderMount, meshGradientFragmentShader, getShaderColorFromString } from '@paper-design/shaders';
 
-const myCanvas = document.createElement('canvas');
-myCanvas.width = 300;
-myCanvas.height = 300;
+const myDiv = document.createElement('div');
 document.body.appendChild(myCanvas);
+myDiv.style.width = '600px';
+myDiv.style.height = '400px';
 
 const shaderParams = {
   u_color1: getShaderColorFromString('#283BFC'),
@@ -89,7 +89,8 @@ const shaderParams = {
   u_color4: getShaderColorFromString('#800080'),
 };
 
-const meshGradient = new ShaderMount(myCanvas, meshGradientFragmentShader, shaderParams, undefined, 0.25);
+const speed = 0.25;
+const meshGradient = new ShaderMount(myDiv, meshGradientFragmentShader, shaderParams, undefined, speed);
 ```
 
 ## Roadmap:

--- a/docs/src/app/dot-grid/page.tsx
+++ b/docs/src/app/dot-grid/page.tsx
@@ -91,7 +91,7 @@ const DotGridWithControls = () => {
       <Link href="/">
         <BackButton />
       </Link>
-      <DotGrid {...params} style={{ position: 'fixed', width: '100%', height: '100%', ...style }} />
+      <DotGrid {...params} style={{ position: 'fixed', width: '100svw', height: '100svh', ...style }} />
     </>
   );
 };

--- a/docs/src/app/dot-orbit/page.tsx
+++ b/docs/src/app/dot-orbit/page.tsx
@@ -69,7 +69,7 @@ const DotOrbitWithControls = () => {
       <Link href="/">
         <BackButton />
       </Link>
-      <DotOrbit {...params} style={{ position: 'fixed', width: '100%', height: '100%' }} />
+      <DotOrbit {...params} style={{ position: 'fixed', width: '100svw', height: '100svh' }} />
     </>
   );
 };

--- a/docs/src/app/god-rays/page.tsx
+++ b/docs/src/app/god-rays/page.tsx
@@ -77,7 +77,7 @@ const GodRaysWithControls = () => {
       <Link href="/">
         <BackButton />
       </Link>
-      <GodRays {...params} style={{ position: 'fixed', width: '100%', height: '100%' }} />
+      <GodRays {...params} style={{ position: 'fixed', width: '100svw', height: '100svh' }} />
     </>
   );
 };

--- a/docs/src/app/mesh-gradient/page.tsx
+++ b/docs/src/app/mesh-gradient/page.tsx
@@ -62,7 +62,7 @@ const MeshGradientWithControls = () => {
       <Link href="/">
         <BackButton />
       </Link>
-      <MeshGradient {...params} style={{ position: 'fixed', width: '100%', height: '100%' }} />
+      <MeshGradient {...params} style={{ position: 'fixed', width: '100svw', height: '100svh' }} />
     </>
   );
 };

--- a/docs/src/app/metaballs/page.tsx
+++ b/docs/src/app/metaballs/page.tsx
@@ -85,7 +85,7 @@ const MetaballsWithControls = () => {
       <Link href="/">
         <BackButton />
       </Link>
-      <Metaballs {...params} style={{ position: 'fixed', width: '100%', height: '100%', ...style }} />
+      <Metaballs {...params} style={{ position: 'fixed', width: '100svw', height: '100svh', ...style }} />
     </>
   );
 };

--- a/docs/src/app/neuro-noise/page.tsx
+++ b/docs/src/app/neuro-noise/page.tsx
@@ -62,7 +62,7 @@ const NeuroNoiseWithControls = () => {
       <Link href="/">
         <BackButton />
       </Link>
-      <NeuroNoise {...params} style={{ position: 'fixed', width: '100%', height: '100%' }} />
+      <NeuroNoise {...params} style={{ position: 'fixed', width: '100svw', height: '100svh' }} />
     </>
   );
 };

--- a/docs/src/app/perlin-noise/page.tsx
+++ b/docs/src/app/perlin-noise/page.tsx
@@ -86,7 +86,7 @@ const PerlinNoiseWithControls = () => {
       <Link href="/">
         <BackButton />
       </Link>
-      <PerlinNoise {...params} style={{ position: 'fixed', width: '100%', height: '100%', ...style }} />
+      <PerlinNoise {...params} style={{ position: 'fixed', width: '100svw', height: '100svh', ...style }} />
     </>
   );
 };

--- a/docs/src/app/smoke-ring/page.tsx
+++ b/docs/src/app/smoke-ring/page.tsx
@@ -96,7 +96,7 @@ const SmokeRingWithControls = () => {
       <Link href="/">
         <BackButton />
       </Link>
-      <SmokeRing {...shaderParams} style={{ position: 'fixed', width: '100%', height: '100%', ...style }} />
+      <SmokeRing {...shaderParams} style={{ position: 'fixed', width: '100svw', height: '100svh', ...style }} />
     </>
   );
 };

--- a/docs/src/app/spiral/page.tsx
+++ b/docs/src/app/spiral/page.tsx
@@ -98,7 +98,7 @@ const SpiralWithControls = () => {
       <Link href="/">
         <BackButton />
       </Link>
-      <Spiral {...shaderParams} style={{ position: 'fixed', width: '100%', height: '100%' }} />
+      <Spiral {...shaderParams} style={{ position: 'fixed', width: '100svw', height: '100svh' }} />
     </>
   );
 };

--- a/docs/src/app/stepped-simplex-noise/page.tsx
+++ b/docs/src/app/stepped-simplex-noise/page.tsx
@@ -75,7 +75,7 @@ const SteppedSimplexNoiseWithControls = () => {
       <Link href="/">
         <BackButton />
       </Link>
-      <SteppedSimplexNoise {...params} style={{ position: 'fixed', width: '100%', height: '100%' }} />
+      <SteppedSimplexNoise {...params} style={{ position: 'fixed', width: '100svw', height: '100svh' }} />
     </>
   );
 };

--- a/docs/src/app/voronoi/page.tsx
+++ b/docs/src/app/voronoi/page.tsx
@@ -72,7 +72,7 @@ const VoronoiWithControls = () => {
       <Link href="/">
         <BackButton />
       </Link>
-      <Voronoi {...params} style={{ position: 'fixed', width: '100%', height: '100%' }} />
+      <Voronoi {...params} style={{ position: 'fixed', width: '100svw', height: '100svh' }} />
     </>
   );
 };

--- a/docs/src/app/warp/page.tsx
+++ b/docs/src/app/warp/page.tsx
@@ -79,7 +79,7 @@ const WarpWithControls = () => {
       <Link href="/">
         <BackButton />
       </Link>
-      <Warp {...params} style={{ position: 'fixed', width: '100%', height: '100%' }} />
+      <Warp {...params} style={{ position: 'fixed', width: '100svw', height: '100svh' }} />
     </>
   );
 };

--- a/docs/src/app/waves/page.tsx
+++ b/docs/src/app/waves/page.tsx
@@ -90,7 +90,7 @@ const WavesWithControls = () => {
       <Link href="/">
         <BackButton />
       </Link>
-      <Waves {...params} style={{ position: 'fixed', width: '100%', height: '100%', ...style }} />
+      <Waves {...params} style={{ position: 'fixed', width: '100svw', height: '100svh', ...style }} />
     </>
   );
 };

--- a/packages/shaders-react/package.json
+++ b/packages/shaders-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paper-design/shaders-react",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "license": "MIT",
   "type": "module",
   "publishConfig": {

--- a/packages/shaders-react/src/shader-mount.tsx
+++ b/packages/shaders-react/src/shader-mount.tsx
@@ -5,8 +5,8 @@ import { useMergeRefs } from './use-merge-refs';
 /** The React ShaderMount can also accept strings as uniform values, which will assumed to be URLs and loaded as images */
 export type ShaderMountUniformsReact = { [key: string]: ShaderMountUniforms[keyof ShaderMountUniforms] | string };
 
-export interface ShaderMountProps extends React.ComponentProps<'canvas'> {
-  shaderMountRef?: React.MutableRefObject<ShaderMountVanilla | null>;
+export interface ShaderMountProps extends React.ComponentProps<'div'> {
+  shaderMountRef?: React.RefObject<ShaderMountVanilla | null>;
   fragmentShader: string;
   uniforms?: ShaderMountUniformsReact;
   webGlContextAttributes?: WebGLContextAttributes;
@@ -80,7 +80,7 @@ const processUniforms = (uniforms: ShaderMountUniformsReact): Promise<ShaderMoun
  * A React component that mounts a shader and updates its uniforms as the component's props change
  * If you pass a string as a uniform value, it will be assumed to be a URL and attempted to be loaded as an image
  */
-export const ShaderMount: React.FC<ShaderMountProps> = forwardRef<HTMLCanvasElement, ShaderMountProps>(
+export const ShaderMount: React.FC<ShaderMountProps> = forwardRef<HTMLDivElement, ShaderMountProps>(
   function ShaderMountImpl(
     {
       shaderMountRef: externalShaderMountRef,
@@ -89,20 +89,20 @@ export const ShaderMount: React.FC<ShaderMountProps> = forwardRef<HTMLCanvasElem
       webGlContextAttributes,
       speed = 1,
       frame = 0,
-      ...canvasProps
+      ...divProps
     },
     forwardedRef
   ) {
-    const canvasRef = useRef<HTMLCanvasElement>(null);
-    const shaderMountRef: React.MutableRefObject<ShaderMountVanilla | null> = useRef<ShaderMountVanilla>(null);
+    const divRef = useRef<HTMLDivElement>(null);
+    const shaderMountRef: React.RefObject<ShaderMountVanilla | null> = useRef<ShaderMountVanilla>(null);
 
     useEffect(() => {
       const initShader = async () => {
         const processedUniforms = await processUniforms(uniforms);
 
-        if (canvasRef.current && !shaderMountRef.current) {
+        if (divRef.current && !shaderMountRef.current) {
           shaderMountRef.current = new ShaderMountVanilla(
-            canvasRef.current,
+            divRef.current,
             fragmentShader,
             processedUniforms,
             webGlContextAttributes,
@@ -141,7 +141,7 @@ export const ShaderMount: React.FC<ShaderMountProps> = forwardRef<HTMLCanvasElem
       shaderMountRef.current?.setFrame(frame);
     }, [frame]);
 
-    return <canvas ref={useMergeRefs([canvasRef, forwardedRef])} {...canvasProps} />;
+    return <div ref={useMergeRefs([divRef, forwardedRef])} {...divProps} />;
   }
 );
 

--- a/packages/shaders/README.md
+++ b/packages/shaders/README.md
@@ -7,10 +7,10 @@ This is the vanilla JS of Paper Shaders. You can also find framework specific wr
 ```
 import { ShaderMount, meshGradientFragmentShader, getShaderColorFromString } from "@paper-design/shaders";
 
-const myCanvas = document.createElement("canvas");
-myCanvas.width = 300;
-myCanvas.height = 300;
+const myDiv = document.createElement('div');
 document.body.appendChild(myCanvas);
+myDiv.style.width = '600px';
+myDiv.style.height = '400px';
 
 const shaderParams = {
   u_color1: getShaderColorFromString("#283BFC"),
@@ -19,9 +19,6 @@ const shaderParams = {
   u_color4: getShaderColorFromString("#800080")
 };
 
-const meshGradient = new ShaderMount(
-  myCanvas,
-  meshGradientFragmentShader,
-  shaderParams
-);
+const speed = 0.25;
+const meshGradient = new ShaderMount(myDiv, meshGradientFragmentShader, shaderParams, undefined, speed);
 ```

--- a/packages/shaders/package.json
+++ b/packages/shaders/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paper-design/shaders",
-  "version": "0.0.23",
+  "version": "0.0.24",
   "license": "MIT",
   "type": "module",
   "publishConfig": {

--- a/packages/shaders/src/shader-mount.ts
+++ b/packages/shaders/src/shader-mount.ts
@@ -138,7 +138,9 @@ export class ShaderMount {
     this.handleResize();
   };
 
-  renderScale = 1;
+  /** The scale that we should render at (prevents the virtual resolution from going beyond our maxium and then multiplies by pixelRatio (at least 2X rendering always) */
+  private renderScale = 1;
+  /** Resize handler for when the container div changes size and we want to resize our canvas to match */
   private handleResize = () => {
     const clientWidth = this.mountToDiv.clientWidth;
     const clientHeight = this.mountToDiv.clientHeight;

--- a/packages/shaders/src/shader-mount.ts
+++ b/packages/shaders/src/shader-mount.ts
@@ -11,7 +11,8 @@ export function isPaperShaderCanvas(canvas: HTMLCanvasElement): canvas is PaperS
 }
 
 export class ShaderMount {
-  private canvas: PaperShaderCanvasElement;
+  public mountToDiv: HTMLDivElement;
+  public canvas: PaperShaderCanvasElement;
   private gl: WebGLRenderingContext;
   private program: WebGLProgram | null = null;
   private uniformLocations: Record<string, WebGLUniformLocation | null> = {};
@@ -37,7 +38,8 @@ export class ShaderMount {
   private maxResolution = 0; // set by constructor
 
   constructor(
-    canvas: HTMLCanvasElement,
+    /** The div you'd like to mount the shader to. The shader will match its size. */
+    mountToDiv: HTMLDivElement,
     fragmentShader: string,
     uniforms: ShaderMountUniforms = {},
     webGlContextAttributes?: WebGLContextAttributes,
@@ -48,12 +50,23 @@ export class ShaderMount {
     /** The maximum resolution (on the larger axis) that we render for the shader. Use virtual pixels, will be multiplied by display DPI to get the actual resolution. Actual CSS size of the canvas can be larger, it will just lose quality after this */
     maxResolution = 1920
   ) {
+    // Create the canvas element and mount it into the provided div
+    const canvas = document.createElement('canvas');
+    mountToDiv.style.contain = 'strict';
+    mountToDiv.style.position = 'relative';
+    canvas.style.position = 'absolute';
+    canvas.style.inset = '0';
+    canvas.style.zIndex = '-1';
+    canvas.style.width = '100%';
+    canvas.style.height = '100%';
     this.canvas = canvas as PaperShaderCanvasElement;
+    this.mountToDiv = mountToDiv;
+    mountToDiv.appendChild(canvas);
     this.fragmentShader = fragmentShader;
     this.providedUniforms = uniforms;
     // Base our starting animation time on the provided frame value
     this.totalFrameTime = frame;
-    this.maxResolution = maxResolution * window.devicePixelRatio;
+    this.maxResolution = maxResolution;
 
     const gl = canvas.getContext('webgl2', webGlContextAttributes);
     if (!gl) {
@@ -121,41 +134,25 @@ export class ShaderMount {
   private resizeObserver: ResizeObserver | null = null;
   private setupResizeObserver = () => {
     this.resizeObserver = new ResizeObserver(() => this.handleResize());
-    this.resizeObserver.observe(this.canvas);
+    this.resizeObserver.observe(this.mountToDiv);
     this.handleResize();
   };
 
-  private lastCSSWidth = 0;
-  private lastCSSHeight = 0;
+  renderScale = 1;
   private handleResize = () => {
-    const clientWidth = this.canvas.clientWidth;
-    const clientHeight = this.canvas.clientHeight;
-    const pixelRatio = window.devicePixelRatio;
+    const clientWidth = this.mountToDiv.clientWidth;
+    const clientHeight = this.mountToDiv.clientHeight;
+    const maxResolution = this.maxResolution;
+    // Note we render at 2X even for 1x screens because it gives a much smoother looking result
+    const pixelRatio = Math.max(2, window.devicePixelRatio);
+    // Render scale prevents the virtual resolution from going beyond our maxium and then multiplies by pixelRatio (so at least 2X rendering)
+    this.renderScale = Math.min(1, maxResolution / Math.max(clientWidth, clientHeight)) * pixelRatio;
 
-    let newWidth = clientWidth * pixelRatio;
-    let newHeight = clientHeight * pixelRatio;
-    // Prevent the size from going larger than our max resolution
-    const scale = Math.min(1, this.maxResolution / Math.max(newWidth, newHeight));
-    newWidth = Math.floor(newWidth * scale);
-    newHeight = Math.floor(newHeight * scale);
-
+    let newWidth = clientWidth * this.renderScale;
+    let newHeight = clientHeight * this.renderScale;
     if (this.canvas.width !== newWidth || this.canvas.height !== newHeight) {
       this.canvas.width = newWidth;
       this.canvas.height = newHeight;
-
-      // If pixelRatio is not 1, we need the user to set a CSS size or changing the canvas.width/height will
-      // actually resize the element, triggering a resize loop and making the result still 1x dpi, just bigger
-      if (pixelRatio !== 1) {
-        this.lastCSSWidth = parseFloat(window.getComputedStyle(this.canvas).width);
-        this.lastCSSHeight = parseFloat(window.getComputedStyle(this.canvas).height);
-        // CSS width should not equal newWidth, because newWidth is scaled with dpi
-        if (this.lastCSSWidth === newWidth && this.lastCSSHeight === newHeight) {
-          // It appears that CSS sizing was unset, so we just caused the entire canvas to resize and will trigger a resize loop
-          // Set an explicit inline CSS size to avoid the loop and preserve 2x rendering
-          this.canvas.style.width = `${clientWidth}px`;
-          this.canvas.style.height = `${clientHeight}px`;
-        }
-      }
 
       this.resolutionChanged = true;
       this.gl.viewport(0, 0, this.gl.canvas.width, this.gl.canvas.height);
@@ -191,8 +188,7 @@ export class ShaderMount {
     // If the resolution has changed, we need to update the uniform
     if (this.resolutionChanged) {
       this.gl.uniform2f(this.uniformLocations.u_resolution!, this.gl.canvas.width, this.gl.canvas.height);
-      const pixelRatio = this.gl.canvas.width / this.lastCSSWidth;
-      this.gl.uniform1f(this.uniformLocations.u_pixelRatio!, pixelRatio);
+      this.gl.uniform1f(this.uniformLocations.u_pixelRatio!, this.renderScale);
       this.resolutionChanged = false;
     }
 


### PR DESCRIPTION
- Fixes issues with 1X rendering
- Removes the need to check for infinite resizing loops
- Supports nesting children into the shaders (useful in Paper) to use the shader for backgrounds or borders
- We always render at least at 2X, even for 1X screens, which reduces pixelation quite a bit on 1X screens