### PR TITLE
Fix CSS layering edge case

### DIFF
--- a/packages/shaders/src/shader-mount.ts
+++ b/packages/shaders/src/shader-mount.ts
@@ -545,8 +545,8 @@ vec3 getBoxSize(float boxRatio, vec2 givenBoxSize, vec2 maxBoxSize) {
 
 void main() {
   gl_Position = a_position;
-  
-  vec2 uv = gl_Position.xy * .5;  
+
+  vec2 uv = gl_Position.xy * .5;
   vec2 boxOrigin = vec2(.5 - u_originX, u_originY - .5);
   vec2 givenBoxSize = vec2(u_worldWidth, u_worldHeight);
   givenBoxSize = max(givenBoxSize, vec2(1.)) * u_pixelRatio;
@@ -554,12 +554,12 @@ void main() {
   float r = u_rotation * 3.14159265358979323846 / 180.;
   mat2 graphicRotation = mat2(cos(r), sin(r), -sin(r), cos(r));
   vec2 graphicOffset = vec2(-u_offsetX, u_offsetY);
-  
-  
+
+
   // ===================================================
   // Sizing api for graphic objects with fixed ratio
   // (currently supports only ratio = 1)
-  
+
   float fixedRatio = 1.;
   vec2 fixedRatioBoxGivenSize = vec2(
     (u_worldWidth == 0.) ? u_resolution.x : givenBoxSize.x,
@@ -574,22 +574,22 @@ void main() {
     v_objectHelperBox *= objectWorldScale;
     v_objectHelperBox += boxOrigin * (objectWorldScale - 1.);
   #endif
-  
+
   v_objectUV = uv;
   v_objectUV *= objectWorldScale;
   v_objectUV += boxOrigin * (objectWorldScale - 1.);
   v_objectUV += graphicOffset;
   v_objectUV /= u_scale;
   v_objectUV = graphicRotation * v_objectUV;
-  
+
 
   // ===================================================
-  
-  
+
+
   // ===================================================
   // Sizing api for graphic objects with either givenBoxSize ratio or canvas ratio.
   // Full-screen mode available with u_worldWidth = u_worldHeight = 0
-  
+
   v_responsiveBoxGivenSize = vec2(
     (u_worldWidth == 0.) ? u_resolution.x : givenBoxSize.x,
     (u_worldHeight == 0.) ? u_resolution.y : givenBoxSize.y
@@ -597,13 +597,13 @@ void main() {
   float responsiveRatio = v_responsiveBoxGivenSize.x / v_responsiveBoxGivenSize.y;
   v_responsiveBoxSize = getBoxSize(responsiveRatio, v_responsiveBoxGivenSize, maxBoxSize).xy;
   vec2 responsiveBoxScale = u_resolution.xy / v_responsiveBoxSize;
-  
+
   #ifdef ADD_HELPERS
     v_responsiveHelperBox = uv;
     v_responsiveHelperBox *= responsiveBoxScale;
     v_responsiveHelperBox += boxOrigin * (responsiveBoxScale - 1.);
   #endif
-  
+
   v_responsiveUV = uv;
   v_responsiveUV *= responsiveBoxScale;
   v_responsiveUV += boxOrigin * (responsiveBoxScale - 1.);
@@ -615,29 +615,29 @@ void main() {
 
   // ===================================================
 
-  
+
   // ===================================================
-  // Sizing api for patterns 
+  // Sizing api for patterns
   // (treating graphics as a image u_worldWidth x u_worldHeight size)
-  
-  float patternBoxRatio = givenBoxSize.x / givenBoxSize.y;  
+
+  float patternBoxRatio = givenBoxSize.x / givenBoxSize.y;
   vec2 patternBoxGivenSize = vec2(
     (u_worldWidth == 0.) ? u_resolution.x : givenBoxSize.x,
     (u_worldHeight == 0.) ? u_resolution.y : givenBoxSize.y
   );
   patternBoxRatio = patternBoxGivenSize.x / patternBoxGivenSize.y;
-  
+
   vec3 boxSizeData = getBoxSize(patternBoxRatio, patternBoxGivenSize, maxBoxSize);
   v_patternBoxSize = boxSizeData.xy;
   float patternBoxNoFitBoxWidth = boxSizeData.z;
   vec2 patternBoxScale = u_resolution.xy / v_patternBoxSize;
-  
+
   #ifdef ADD_HELPERS
     v_patternHelperBox = uv;
     v_patternHelperBox *= patternBoxScale;
     v_patternHelperBox += boxOrigin * (patternBoxScale - 1.);
   #endif
-  
+
   v_patternUV = uv;
   v_patternUV += graphicOffset / patternBoxScale;
   v_patternUV += boxOrigin;
@@ -652,7 +652,7 @@ void main() {
   v_patternUV += boxOrigin / patternBoxScale;
   v_patternUV -= boxOrigin;
   v_patternUV += .5;
-  
+
   // ===================================================
 
 }`;
@@ -707,7 +707,7 @@ function createProgram(
   return program;
 }
 
-const defaultStyle = `@layer base {
+const defaultStyle = `@layer paper-shaders {
   :where([data-paper-shaders]) {
     isolation: isolate;
     position: relative;


### PR DESCRIPTION
Renaming our CSS layer to a unique identifier to avoid breaking things like this:

```
// from shaders
@layer base {
  // shader style
}

// A site's own CSS declares layering order later:
@layer theme, base, components;
```