### PR TITLE
add backbuffer rendering

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -44,7 +44,7 @@
       "name": "@paper-design/shaders-react",
       "version": "0.0.33",
       "dependencies": {
-        "@paper-design/shaders": "0.0.29",
+        "@paper-design/shaders": "workspace:*",
       },
       "devDependencies": {
         "@types/react": "19.1.0",
@@ -1269,8 +1269,6 @@
     "@humanfs/node/@humanwhocodes/retry": ["@humanwhocodes/retry@0.3.1", "", {}, "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA=="],
 
     "@next/eslint-plugin-next/fast-glob": ["fast-glob@3.3.1", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.4" } }, "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg=="],
-
-    "@paper-design/shaders-react/@paper-design/shaders": ["@paper-design/shaders@0.0.29", "", {}, "sha512-nxm0j6O5k+sTsVFTid5Z+vfcMXWiivSpR5u//lvvpO1I4yR+fKfi78H41o8decx2FdS3wnpYqSZVFk+YvrlY8Q=="],
 
     "@radix-ui/react-arrow/@radix-ui/react-primitive": ["@radix-ui/react-primitive@0.1.3", "", { "dependencies": { "@babel/runtime": "^7.13.10", "@radix-ui/react-slot": "0.1.2" }, "peerDependencies": { "react": "^16.8 || ^17.0" } }, "sha512-fcyADaaAx2jdqEDLsTs6aX50S3L1c9K9CC6XMpJpuXFJCU4n9PGTFDZRtY2gAoXXoRCPIBsklCopSmGb6SsDjQ=="],
 

--- a/docs/src/app/foobar/page.tsx
+++ b/docs/src/app/foobar/page.tsx
@@ -1,0 +1,3 @@
+import { GodRays } from '@paper-design/shaders-react';
+const MyTest = () => <GodRays style={{ width: '100vw', height: '100vh' }} />;
+export default MyTest;

--- a/docs/src/app/foobar/page.tsx
+++ b/docs/src/app/foobar/page.tsx
@@ -1,3 +1,0 @@
-import { GodRays } from '@paper-design/shaders-react';
-const MyTest = () => <GodRays style={{ width: '100vw', height: '100vh' }} />;
-export default MyTest;

--- a/docs/src/app/grain-gradient/page.tsx
+++ b/docs/src/app/grain-gradient/page.tsx
@@ -22,8 +22,6 @@ const GrainGradientExample = () => {
  * This example has controls added so you can play with settings in the example app
  */
 
-const MAX_PIXEL_COUNT = 1920 * 1080 * 2;
-
 const { worldWidth, worldHeight, ...defaults } = grainGradientPresets[0].params;
 
 const GrainGradientWithControls = () => {
@@ -32,7 +30,7 @@ const GrainGradientWithControls = () => {
     maxColorCount: grainGradientMeta.maxColorCount,
   });
 
-  const [{ logMaxPixelCount, ...params }, setParams] = useControls(() => {
+  const [params, setParams] = useControls(() => {
     return {
       Parameters: folder(
         {
@@ -73,15 +71,6 @@ const GrainGradientWithControls = () => {
           collapsed: true,
         }
       ),
-      Resolution: folder(
-        {
-          logMaxPixelCount: { value: Math.log(MAX_PIXEL_COUNT), min: 0, max: Math.log(MAX_PIXEL_COUNT), order: 409 },
-        },
-        {
-          order: 4,
-          collapsed: false,
-        }
-      ),
     };
   }, [colors.length]);
 
@@ -112,12 +101,7 @@ const GrainGradientWithControls = () => {
       <Link href="/">
         <BackButton />
       </Link>
-      <GrainGradient
-        {...params}
-        colors={colors}
-        className="fixed size-full"
-        maxPixelCount={Math.exp(logMaxPixelCount)}
-      />
+      <GrainGradient {...params} colors={colors} className="fixed size-full" />
     </>
   );
 };

--- a/docs/src/app/grain-gradient/page.tsx
+++ b/docs/src/app/grain-gradient/page.tsx
@@ -22,6 +22,8 @@ const GrainGradientExample = () => {
  * This example has controls added so you can play with settings in the example app
  */
 
+const MAX_PIXEL_COUNT = 1920 * 1080 * 2;
+
 const { worldWidth, worldHeight, ...defaults } = grainGradientPresets[0].params;
 
 const GrainGradientWithControls = () => {
@@ -30,7 +32,7 @@ const GrainGradientWithControls = () => {
     maxColorCount: grainGradientMeta.maxColorCount,
   });
 
-  const [params, setParams] = useControls(() => {
+  const [{ logMaxPixelCount, ...params }, setParams] = useControls(() => {
     return {
       Parameters: folder(
         {
@@ -71,6 +73,15 @@ const GrainGradientWithControls = () => {
           collapsed: true,
         }
       ),
+      Resolution: folder(
+        {
+          logMaxPixelCount: { value: Math.log(MAX_PIXEL_COUNT), min: 0, max: Math.log(MAX_PIXEL_COUNT), order: 409 },
+        },
+        {
+          order: 4,
+          collapsed: false,
+        }
+      ),
     };
   }, [colors.length]);
 
@@ -101,7 +112,12 @@ const GrainGradientWithControls = () => {
       <Link href="/">
         <BackButton />
       </Link>
-      <GrainGradient {...params} colors={colors} className="fixed size-full" />
+      <GrainGradient
+        {...params}
+        colors={colors}
+        className="fixed size-full"
+        maxPixelCount={Math.exp(logMaxPixelCount)}
+      />
     </>
   );
 };

--- a/docs/src/app/grain-gradient/page.tsx
+++ b/docs/src/app/grain-gradient/page.tsx
@@ -25,13 +25,15 @@ const GrainGradientExample = () => {
 
 const { worldWidth, worldHeight, ...defaults } = grainGradientPresets[0].params;
 
+const MAX_PIXEL_COUNT = 1920 * 1080 * 2;
+
 const GrainGradientWithControls = () => {
   const { colors, setColors } = useColors({
     defaultColors: defaults.colors,
     maxColorCount: grainGradientMeta.maxColorCount,
   });
 
-  const [params, setParams] = useControls(() => {
+  const [{ logMaxPixelCount, ...params }, setParams] = useControls(() => {
     return {
       Parameters: folder(
         {
@@ -73,6 +75,9 @@ const GrainGradientWithControls = () => {
           collapsed: true,
         }
       ),
+      Resolution: folder({
+        logMaxPixelCount: { value: Math.log(MAX_PIXEL_COUNT), min: 0, max: Math.log(MAX_PIXEL_COUNT), order: 409 },
+      }),
     };
   }, [colors.length]);
 
@@ -103,7 +108,12 @@ const GrainGradientWithControls = () => {
       <Link href="/">
         <BackButton />
       </Link>
-      <GrainGradient {...params} colors={colors} className="fixed size-full" />
+      <GrainGradient
+        {...params}
+        colors={colors}
+        className="fixed size-full"
+        maxPixelCount={Math.exp(logMaxPixelCount)}
+      />
     </>
   );
 };

--- a/packages/shaders-react/package.json
+++ b/packages/shaders-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paper-design/shaders-react",
-  "version": "0.0.33",
+  "version": "0.0.33-backbuffer-experiment.0",
   "license": "MIT",
   "type": "module",
   "sideEffects": false,

--- a/packages/shaders-react/package.json
+++ b/packages/shaders-react/package.json
@@ -24,7 +24,7 @@
     "type-check": "tsc --project tsconfig.json"
   },
   "dependencies": {
-    "@paper-design/shaders": "0.0.29"
+    "@paper-design/shaders": "workspace:*"
   },
   "devDependencies": {
     "@types/react": "19.1.0"

--- a/packages/shaders/package.json
+++ b/packages/shaders/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paper-design/shaders",
-  "version": "0.0.30",
+  "version": "0.0.30-backbuffer-experiment.0",
   "license": "MIT",
   "type": "module",
   "sideEffects": false,

--- a/packages/shaders/src/shader-mount.ts
+++ b/packages/shaders/src/shader-mount.ts
@@ -476,8 +476,8 @@ export class ShaderMount {
     // Set texture parameters
     this.gl.texParameteri(this.gl.TEXTURE_2D, this.gl.TEXTURE_WRAP_S, this.gl.REPEAT);
     this.gl.texParameteri(this.gl.TEXTURE_2D, this.gl.TEXTURE_WRAP_T, this.gl.REPEAT);
-    this.gl.texParameteri(this.gl.TEXTURE_2D, this.gl.TEXTURE_MIN_FILTER, this.gl.NEAREST);
-    this.gl.texParameteri(this.gl.TEXTURE_2D, this.gl.TEXTURE_MAG_FILTER, this.gl.NEAREST);
+    this.gl.texParameteri(this.gl.TEXTURE_2D, this.gl.TEXTURE_MIN_FILTER, this.gl.LINEAR);
+    this.gl.texParameteri(this.gl.TEXTURE_2D, this.gl.TEXTURE_MAG_FILTER, this.gl.LINEAR);
 
     // Upload image to texture
     this.gl.texImage2D(this.gl.TEXTURE_2D, 0, this.gl.RGBA, this.gl.RGBA, this.gl.UNSIGNED_BYTE, image);
@@ -665,8 +665,8 @@ export class ShaderMount {
       null
     );
 
-    this.gl.texParameteri(this.gl.TEXTURE_2D, this.gl.TEXTURE_MIN_FILTER, this.gl.NEAREST);
-    this.gl.texParameteri(this.gl.TEXTURE_2D, this.gl.TEXTURE_MAG_FILTER, this.gl.NEAREST);
+    this.gl.texParameteri(this.gl.TEXTURE_2D, this.gl.TEXTURE_MIN_FILTER, this.gl.LINEAR);
+    this.gl.texParameteri(this.gl.TEXTURE_2D, this.gl.TEXTURE_MAG_FILTER, this.gl.LINEAR);
 
     // We need clamp to edge to avoid sampling artifacts from outside the canvas
     this.gl.texParameteri(this.gl.TEXTURE_2D, this.gl.TEXTURE_WRAP_S, this.gl.CLAMP_TO_EDGE);

--- a/packages/shaders/src/shader-mount.ts
+++ b/packages/shaders/src/shader-mount.ts
@@ -258,7 +258,7 @@ export class ShaderMount {
       cancelAnimationFrame(this.resizeRafId);
     }
 
-    const { width, height, renderScale } = this.calculateCanvasData();
+    const { width, height, renderScale } = this.getCanvasSize();
 
     if (
       this.canvasElement.width !== width ||
@@ -276,7 +276,7 @@ export class ShaderMount {
     }
   };
 
-  private calculateCanvasData = () => {
+  private getCanvasSize = () => {
     const pinchZoom = visualViewport?.scale ?? 1;
 
     // Zoom level can be calculated comparing the browser's outerWidth and the viewport width.
@@ -312,16 +312,10 @@ export class ShaderMount {
   };
 
   private handleResolutionChange = () => {
-    const { width: newWidth, height: newHeight, renderScale: newRenderScale } = this.calculateCanvasData();
+    const { renderScale } = this.getCanvasSize();
 
-    if (
-      this.canvasElement.width !== newWidth ||
-      this.canvasElement.height !== newHeight ||
-      this.renderScale !== newRenderScale
-    ) {
-      this.renderScale = newRenderScale;
-      this.canvasElement.width = newWidth;
-      this.canvasElement.height = newHeight;
+    if (this.renderScale !== renderScale) {
+      this.renderScale = renderScale;
       this.resolutionChanged = true;
     }
   };
@@ -523,7 +517,6 @@ export class ShaderMount {
       }
 
       if (value instanceof HTMLImageElement) {
-        console.log('setting texture uniform', key);
         // Texture case, requires a good amount of code so it gets its own function:
         this.setTextureUniform(key, value);
       } else if (Array.isArray(value)) {

--- a/packages/shaders/src/shader-mount.ts
+++ b/packages/shaders/src/shader-mount.ts
@@ -312,10 +312,16 @@ export class ShaderMount {
   };
 
   private handleResolutionChange = () => {
-    const { renderScale } = this.getCanvasSize();
+    const { renderScale, width, height } = this.getCanvasSize();
 
-    if (this.renderScale !== renderScale) {
+    if (
+      this.renderScale !== renderScale ||
+      this.canvasElement.width !== width ||
+      this.canvasElement.height !== height
+    ) {
       this.renderScale = renderScale;
+      this.canvasElement.width = width;
+      this.canvasElement.height = height;
       this.resolutionChanged = true;
     }
   };
@@ -422,6 +428,7 @@ export class ShaderMount {
 
     // Render framebuffer to canvas
     this.gl.bindFramebuffer(this.gl.FRAMEBUFFER, null);
+    // console.log('render', this.gl.canvas.width, this.gl.canvas.height);
     this.gl.viewport(0, 0, this.gl.canvas.width, this.gl.canvas.height);
     this.gl.clear(this.gl.COLOR_BUFFER_BIT);
 

--- a/packages/shaders/src/shader-mount.ts
+++ b/packages/shaders/src/shader-mount.ts
@@ -371,7 +371,7 @@ export class ShaderMount {
       const newWidth = Math.round(this.parentWidth * targetRenderScale);
       const newHeight = Math.round(this.parentHeight * targetRenderScale);
 
-      // Set framebuffer size to match maxPixelCount
+      // Set framebuffer size
       const newFramebufferWidth = Math.round(this.parentWidth * newRenderScale);
       const newFramebufferHeight = Math.round(this.parentHeight * newRenderScale);
 
@@ -667,6 +667,10 @@ export class ShaderMount {
 
     this.gl.texParameteri(this.gl.TEXTURE_2D, this.gl.TEXTURE_MIN_FILTER, this.gl.LINEAR);
     this.gl.texParameteri(this.gl.TEXTURE_2D, this.gl.TEXTURE_MAG_FILTER, this.gl.LINEAR);
+
+    // We need clamp to edge to avoid sampling artifacts from outside the canvas
+    this.gl.texParameteri(this.gl.TEXTURE_2D, this.gl.TEXTURE_WRAP_S, this.gl.CLAMP_TO_EDGE);
+    this.gl.texParameteri(this.gl.TEXTURE_2D, this.gl.TEXTURE_WRAP_T, this.gl.CLAMP_TO_EDGE);
 
     this.gl.framebufferTexture2D(
       this.gl.FRAMEBUFFER,

--- a/packages/shaders/src/shader-mount.ts
+++ b/packages/shaders/src/shader-mount.ts
@@ -476,8 +476,8 @@ export class ShaderMount {
     // Set texture parameters
     this.gl.texParameteri(this.gl.TEXTURE_2D, this.gl.TEXTURE_WRAP_S, this.gl.REPEAT);
     this.gl.texParameteri(this.gl.TEXTURE_2D, this.gl.TEXTURE_WRAP_T, this.gl.REPEAT);
-    this.gl.texParameteri(this.gl.TEXTURE_2D, this.gl.TEXTURE_MIN_FILTER, this.gl.LINEAR);
-    this.gl.texParameteri(this.gl.TEXTURE_2D, this.gl.TEXTURE_MAG_FILTER, this.gl.LINEAR);
+    this.gl.texParameteri(this.gl.TEXTURE_2D, this.gl.TEXTURE_MIN_FILTER, this.gl.NEAREST);
+    this.gl.texParameteri(this.gl.TEXTURE_2D, this.gl.TEXTURE_MAG_FILTER, this.gl.NEAREST);
 
     // Upload image to texture
     this.gl.texImage2D(this.gl.TEXTURE_2D, 0, this.gl.RGBA, this.gl.RGBA, this.gl.UNSIGNED_BYTE, image);
@@ -665,8 +665,8 @@ export class ShaderMount {
       null
     );
 
-    this.gl.texParameteri(this.gl.TEXTURE_2D, this.gl.TEXTURE_MIN_FILTER, this.gl.LINEAR);
-    this.gl.texParameteri(this.gl.TEXTURE_2D, this.gl.TEXTURE_MAG_FILTER, this.gl.LINEAR);
+    this.gl.texParameteri(this.gl.TEXTURE_2D, this.gl.TEXTURE_MIN_FILTER, this.gl.NEAREST);
+    this.gl.texParameteri(this.gl.TEXTURE_2D, this.gl.TEXTURE_MAG_FILTER, this.gl.NEAREST);
 
     // We need clamp to edge to avoid sampling artifacts from outside the canvas
     this.gl.texParameteri(this.gl.TEXTURE_2D, this.gl.TEXTURE_WRAP_S, this.gl.CLAMP_TO_EDGE);

--- a/packages/shaders/src/shader-mount.ts
+++ b/packages/shaders/src/shader-mount.ts
@@ -340,6 +340,9 @@ export class ShaderMount {
       null
     );
 
+    // Bind framebuffer before attaching texture
+    this.gl.bindFramebuffer(this.gl.FRAMEBUFFER, this.framebuffer);
+
     // Attach texture to framebuffer
     this.gl.framebufferTexture2D(
       this.gl.FRAMEBUFFER,

--- a/packages/shaders/src/shader-mount.ts
+++ b/packages/shaders/src/shader-mount.ts
@@ -319,10 +319,6 @@ export class ShaderMount {
     const newWidth = Math.round(this.parentWidth * targetRenderScale);
     const newHeight = Math.round(this.parentHeight * targetRenderScale);
 
-    // Set framebuffer size
-    const newFramebufferWidth = Math.round(this.parentWidth * newRenderScale);
-    const newFramebufferHeight = Math.round(this.parentHeight * newRenderScale);
-
     if (
       this.canvasElement.width !== newWidth ||
       this.canvasElement.height !== newHeight ||
@@ -650,10 +646,12 @@ export class ShaderMount {
         this.gl.deleteFramebuffer(this.framebuffer);
         this.framebuffer = null;
       }
+
       if (this.framebufferTexture) {
         this.gl.deleteTexture(this.framebufferTexture);
         this.framebufferTexture = null;
       }
+
       if (this.framebufferSamplingProgram) {
         this.gl.deleteProgram(this.framebufferSamplingProgram);
         this.framebufferSamplingProgram = null;


### PR DESCRIPTION
<img width="555" alt="image" src="https://github.com/user-attachments/assets/cee3238a-6601-4448-b84f-0a73ca795f3c" />

<img width="555" alt="image" src="https://github.com/user-attachments/assets/599351de-5be8-4ba3-8340-dca95f33ec75" />


Shader gets first rendered to a frameBuffer at full resolution, then sampled at the intended resolution. The `handleResolutionChange` function basically destroys the framebuffer and recreates it, and this is 20x faster than the `handleResize` function.


Lots of code in this PR that can be deleted before merging i.e. all the profiling.
