### PR TITLE
Fix ref types

### DIFF
--- a/packages/shaders-react/src/index.ts
+++ b/packages/shaders-react/src/index.ts
@@ -1,5 +1,5 @@
 export { ShaderMount } from './shader-mount.js';
-export type { ShaderMountProps, ShaderComponentProps, ShaderMountRef } from './shader-mount.js';
+export type { ShaderMountProps, ShaderComponentProps } from './shader-mount.js';
 
 export { MeshGradient, meshGradientPresets } from './shaders/mesh-gradient.js';
 export type { MeshGradientProps } from './shaders/mesh-gradient.js';

--- a/packages/shaders-react/src/shader-mount.tsx
+++ b/packages/shaders-react/src/shader-mount.tsx
@@ -3,21 +3,19 @@
 import { useEffect, useRef, forwardRef, useState } from 'react';
 import {
   ShaderMount as ShaderMountVanilla,
+  type PaperShaderElement,
   type ShaderMotionParams,
   type ShaderMountUniforms,
 } from '@paper-design/shaders';
 import { useMergeRefs } from './use-merge-refs.js';
-
-export interface ShaderMountRef extends HTMLDivElement {
-  paperShaderMount?: ShaderMountVanilla;
-}
 
 /** React Shader Mount can also accept strings as uniform values, which will assumed to be URLs and loaded as images */
 interface ShaderMountUniformsReact {
   [key: string]: string | boolean | number | number[] | number[][] | HTMLImageElement;
 }
 
-export interface ShaderMountProps extends Omit<React.ComponentProps<'div'>, 'color'>, ShaderMotionParams {
+export interface ShaderMountProps extends Omit<React.ComponentProps<'div'>, 'color' | 'ref'>, ShaderMotionParams {
+  ref?: React.RefObject<PaperShaderElement>;
   fragmentShader: string;
   uniforms: ShaderMountUniformsReact;
   minPixelRatio?: number;
@@ -25,7 +23,8 @@ export interface ShaderMountProps extends Omit<React.ComponentProps<'div'>, 'col
   webGlContextAttributes?: WebGLContextAttributes;
 }
 
-export interface ShaderComponentProps extends Omit<React.ComponentProps<'div'>, 'color'> {
+export interface ShaderComponentProps extends Omit<React.ComponentProps<'div'>, 'color' | 'ref'> {
+  ref?: React.RefObject<PaperShaderElement>;
   minPixelRatio?: number;
   maxPixelCount?: number;
   webGlContextAttributes?: WebGLContextAttributes;
@@ -95,7 +94,7 @@ async function processUniforms(uniformsProp: ShaderMountUniformsReact): Promise<
  * A React component that mounts a shader and updates its uniforms as the component's props change
  * If you pass a string as a uniform value, it will be assumed to be a URL and attempted to be loaded as an image
  */
-export const ShaderMount: React.FC<ShaderMountProps> = forwardRef<ShaderMountRef, ShaderMountProps>(
+export const ShaderMount: React.FC<ShaderMountProps> = forwardRef<PaperShaderElement, ShaderMountProps>(
   function ShaderMountImpl(
     {
       fragmentShader,
@@ -110,7 +109,7 @@ export const ShaderMount: React.FC<ShaderMountProps> = forwardRef<ShaderMountRef
     forwardedRef
   ) {
     const [isInitialized, setIsInitialized] = useState(false);
-    const divRef = useRef<HTMLDivElement>(null);
+    const divRef = useRef<PaperShaderElement>(null);
     const shaderMountRef: React.RefObject<ShaderMountVanilla | null> = useRef<ShaderMountVanilla>(null);
 
     // Initialize the ShaderMountVanilla
@@ -172,7 +171,8 @@ export const ShaderMount: React.FC<ShaderMountProps> = forwardRef<ShaderMountRef
       shaderMountRef.current?.setFrame(frame);
     }, [frame, isInitialized]);
 
-    return <div ref={useMergeRefs([divRef, forwardedRef])} {...divProps} />;
+    const mergedRef = useMergeRefs([divRef, forwardedRef]) as unknown as React.RefObject<HTMLDivElement>;
+    return <div ref={mergedRef} {...divProps} />;
   }
 );
 

--- a/packages/shaders/src/shader-mount.ts
+++ b/packages/shaders/src/shader-mount.ts
@@ -754,12 +754,12 @@ const defaultStyle = `@layer paper-shaders {
   }
 }`;
 
-/** A canvas element that has a ShaderMount available on it */
+/** The parent `<div>` element that has a ShaderMount available on it */
 export interface PaperShaderElement extends HTMLElement {
   paperShaderMount: ShaderMount | undefined;
 }
 
-/** Check if a canvas element is a ShaderCanvas */
+/** Check if an element is a Paper shader element */
 export function isPaperShaderElement(element: HTMLElement): element is PaperShaderElement {
   return 'paperShaderMount' in element;
 }

--- a/packages/shaders/src/shader-mount.ts
+++ b/packages/shaders/src/shader-mount.ts
@@ -59,10 +59,10 @@ export class ShaderMount {
       throw new Error('Paper Shaders: parent element must be an HTMLElement');
     }
 
-    if (!document.querySelector('style[data-paper-shaders]')) {
+    if (!document.querySelector('style[data-paper-shader]')) {
       const styleElement = document.createElement('style');
       styleElement.innerHTML = defaultStyle;
-      styleElement.setAttribute('data-paper-shaders', '');
+      styleElement.setAttribute('data-paper-shader', '');
       document.head.prepend(styleElement);
     }
 
@@ -96,7 +96,7 @@ export class ShaderMount {
     this.setSpeed(speed);
 
     // Mark parent element as paper shader mount
-    this.parentElement.setAttribute('data-paper-shaders', '');
+    this.parentElement.setAttribute('data-paper-shader', '');
 
     // Add the shaderMount instance to the div mount element to make it easily accessible
     this.parentElement.paperShaderMount = this;
@@ -737,7 +737,7 @@ function createProgram(
 }
 
 const defaultStyle = `@layer paper-shaders {
-  :where([data-paper-shaders]) {
+  :where([data-paper-shader]) {
     isolation: isolate;
     position: relative;
 


### PR DESCRIPTION
- Fix ref types on the shaders – `<ShaderMount>` had the correct type that included the `paperShaderMount` handle, but all derived shaders used a plain div ref
- Nit: rename `[data-paper-shaders]` into `[data-paper-shader]`, similarly to the `PaperShaderElement` type