### PR TITLE
Add a basic pixelate shader

### DIFF
--- a/docs/registry.json
+++ b/docs/registry.json
@@ -314,6 +314,19 @@
           "type": "registry:component"
         }
       ]
+    },
+    {
+      "name": "pixelate",
+      "type": "registry:component",
+      "title": "Pixelate Example",
+      "description": "Pixelate shader example.",
+      "dependencies": ["@paper-design/shaders-react"],
+      "files": [
+        {
+          "path": "registry/pixelate-example.tsx",
+          "type": "registry:component"
+        }
+      ]
     }
   ]
 }

--- a/docs/registry/pixelate-example.tsx
+++ b/docs/registry/pixelate-example.tsx
@@ -1,0 +1,5 @@
+import { Pixelate, PixelateProps } from '@paper-design/shaders-react';
+
+export function PixelateExample(props: PixelateProps) {
+  return <Pixelate style={{ position: 'fixed', width: '100%', height: '100%' }} {...props} />;
+}

--- a/docs/src/app/pixelate/layout.tsx
+++ b/docs/src/app/pixelate/layout.tsx
@@ -1,0 +1,9 @@
+import { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Pixelate Filter | Paper',
+};
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/docs/src/app/pixelate/page.tsx
+++ b/docs/src/app/pixelate/page.tsx
@@ -1,0 +1,124 @@
+'use client';
+
+import { BackButton } from '@/components/back-button';
+import { cleanUpLevaParams } from '@/helpers/clean-up-leva-params';
+import { levaImageButton } from '@/helpers/leva-image-button';
+import { usePresetHighlight } from '@/helpers/use-preset-highlight';
+import { setParamsSafe, useResetLevaParams } from '@/helpers/use-reset-leva-params';
+import { type ShaderFit, ShaderFitOptions } from '@paper-design/shaders';
+import { Pixelate, pixelatePresets } from '@paper-design/shaders-react';
+import { button, folder, useControls } from 'leva';
+import Link from 'next/link';
+import { useCallback, useEffect, useState } from 'react';
+
+/**
+ * This example has controls added so you can play with settings in the example app
+ */
+
+const { ...defaults } = pixelatePresets[0].params;
+
+const PixelateWithControls = () => {
+  const [imageIdx, setImageIdx] = useState(-1);
+
+  const [image, setImage] = useState<HTMLImageElement | null>(null);
+
+  const imageFiles = [
+    '01.png',
+    '02.jpg',
+    '04.png',
+    '05.jpg',
+    '06.jpg',
+    '07.webp',
+    '08.png',
+    '010.png',
+    '011.png',
+    '012.png',
+    '013.png',
+    '014.png',
+    '015.png',
+    '016.jpg',
+  ] as const;
+
+  useEffect(() => {
+    const img = new Image();
+    img.src = `/images/${imageFiles[imageIdx]}`;
+    img.onload = () => {
+      setImage(img);
+    };
+  }, [imageIdx]);
+
+  const handleClick = useCallback(() => {
+    setImageIdx((prev) => (prev + 1) % imageFiles.length);
+  }, []);
+
+  const [params, setParams] = useControls(() => {
+    const presets = Object.fromEntries(
+      pixelatePresets.map(({ name, params: { worldWidth, worldHeight, ...preset } }) => [
+        name,
+        button(() => setParamsSafe(params, setParams, preset, setImage)),
+      ])
+    );
+    return {
+      Parameters: folder(
+        {
+          sizeX: { value: defaults.sizeX, min: 1, max: 200, step: 1, order: 100 },
+          sizeY: { value: defaults.sizeY, min: 1, max: 200, step: 1, order: 101 },
+        },
+        { order: 1 }
+      ),
+      Transform: folder(
+        {
+          scale: { value: defaults.scale, min: 0.01, max: 4, order: 400 },
+          rotation: { value: defaults.rotation, min: 0, max: 360, order: 401 },
+          offsetX: { value: defaults.offsetX, min: -1, max: 1, order: 402 },
+          offsetY: { value: defaults.offsetY, min: -1, max: 1, order: 403 },
+        },
+        {
+          order: 4,
+          collapsed: true,
+        }
+      ),
+      Fit: folder(
+        {
+          fit: { value: defaults.fit, options: Object.keys(ShaderFitOptions) as ShaderFit[], order: 404 },
+          worldWidth: { value: 0, min: 0, max: 5120, order: 405 },
+          worldHeight: { value: 0, min: 0, max: 5120, order: 406 },
+          originX: { value: defaults.originX, min: 0, max: 1, order: 407 },
+          originY: { value: defaults.originY, min: 0, max: 1, order: 408 },
+        },
+        {
+          order: 5,
+          collapsed: true,
+        }
+      ),
+      Image: folder(
+        {
+          'Upload image': levaImageButton(setImage),
+        },
+        {
+          order: 3,
+          collapsed: false,
+        }
+      ),
+
+      Presets: folder(presets, { order: 10 }),
+    };
+  });
+
+  // Reset to defaults on mount, so that Leva doesn't show values from other
+  // shaders when navigating (if two shaders have a color1 param for example)
+  useResetLevaParams(params, setParams, defaults);
+  usePresetHighlight(pixelatePresets, params);
+  cleanUpLevaParams(params);
+
+  return (
+    <>
+      <Link href="/">
+        <BackButton />
+      </Link>
+      <Pixelate className="fixed size-full" onClick={handleClick} {...params} image={image || undefined} />
+    </>
+  );
+};
+
+export default PixelateWithControls;

--- a/docs/src/home-shaders.ts
+++ b/docs/src/home-shaders.ts
@@ -61,6 +61,8 @@ import {
   flutedGlassPresets,
   Water,
   waterPresets,
+  Pixelate,
+  pixelatePresets,
 } from '@paper-design/shaders-react';
 import { StaticImageData } from 'next/image';
 import TextureTest from './app/texture-test/page';
@@ -237,5 +239,11 @@ export const homeShaders = [
     url: '/fluted-glass',
     ShaderComponent: FlutedGlass,
     shaderConfig: { ...flutedGlassPresets[0].params },
+  },
+  {
+    name: 'pixelate',
+    url: '/pixelate',
+    ShaderComponent: Pixelate,
+    shaderConfig: { ...pixelatePresets[0].params },
   },
 ] satisfies HomeShaderConfig[];

--- a/packages/shaders-react/src/index.ts
+++ b/packages/shaders-react/src/index.ts
@@ -97,6 +97,10 @@ export { Water, waterPresets } from './shaders/water.js';
 export type { WaterProps } from './shaders/water.js';
 export type { WaterUniforms, WaterParams } from '@paper-design/shaders';
 
+export { Pixelate, pixelatePresets } from './shaders/pixelate.js';
+export { type PixelateProps } from './shaders/pixelate.js';
+export { type PixelateUniforms, type PixelateParams } from '@paper-design/shaders';
+
 export { isPaperShaderElement, getShaderColorFromString } from '@paper-design/shaders';
 export type { PaperShaderElement, ShaderFit, ShaderSizingParams, ShaderSizingUniforms } from '@paper-design/shaders';
 

--- a/packages/shaders-react/src/shaders/pixelate.tsx
+++ b/packages/shaders-react/src/shaders/pixelate.tsx
@@ -1,0 +1,73 @@
+import { memo } from 'react';
+import { ShaderMount, type ShaderComponentProps } from '../shader-mount.js';
+import {
+  pixelateFragmentShader,
+  ShaderFitOptions,
+  type PixelateUniforms,
+  type PixelateParams,
+  type ShaderPreset,
+  defaultObjectSizing,
+} from '@paper-design/shaders';
+
+export interface PixelateProps extends ShaderComponentProps, PixelateParams {}
+
+type PixelatePreset = ShaderPreset<PixelateParams>;
+
+export const defaultPreset: PixelatePreset = {
+  name: 'Default',
+  params: {
+    ...defaultObjectSizing,
+    worldWidth: 0,
+    worldHeight: 0,
+    speed: 0,
+    frame: 0,
+    image: '/images/010.png',
+    sizeX: 20,
+    sizeY: 20,
+  },
+};
+
+export const pixelatePresets: PixelatePreset[] = [defaultPreset];
+
+export const Pixelate: React.FC<PixelateProps> = memo(function PixelateImpl({
+  // Own props
+  speed = defaultPreset.params.speed,
+  frame = defaultPreset.params.frame,
+  image = defaultPreset.params.image,
+  sizeX = defaultPreset.params.sizeX,
+  sizeY = defaultPreset.params.sizeY,
+
+  // Sizing props
+  fit = defaultPreset.params.fit,
+  scale = defaultPreset.params.scale,
+  rotation = defaultPreset.params.rotation,
+  originX = defaultPreset.params.originX,
+  originY = defaultPreset.params.originY,
+  offsetX = defaultPreset.params.offsetX,
+  offsetY = defaultPreset.params.offsetY,
+  worldWidth = defaultPreset.params.worldWidth,
+  worldHeight = defaultPreset.params.worldHeight,
+  ...props
+}: PixelateProps) {
+  const uniforms = {
+    // Own uniforms
+    u_image: image,
+    u_size_x: sizeX,
+    u_size_y: sizeY,
+
+    // Sizing uniforms
+    u_fit: ShaderFitOptions[fit],
+    u_scale: scale,
+    u_rotation: rotation,
+    u_offsetX: offsetX,
+    u_offsetY: offsetY,
+    u_originX: originX,
+    u_originY: originY,
+    u_worldWidth: worldWidth,
+    u_worldHeight: worldHeight,
+  } satisfies PixelateUniforms;
+
+  return (
+    <ShaderMount {...props} speed={speed} frame={frame} fragmentShader={pixelateFragmentShader} uniforms={uniforms} />
+  );
+});

--- a/packages/shaders/src/index.ts
+++ b/packages/shaders/src/index.ts
@@ -189,6 +189,8 @@ export {
   type FlutedGlassUniforms,
 } from './shaders/fluted-glass.js';
 
+export { pixelateFragmentShader, type PixelateParams, type PixelateUniforms } from './shaders/pixelate.js';
+
 // ----- Utils ----- //
 export { getShaderColorFromString } from './get-shader-color-from-string.js';
 export { getShaderNoiseTexture } from './get-shader-noise-texture.js';

--- a/packages/shaders/src/shaders/pixelate.ts
+++ b/packages/shaders/src/shaders/pixelate.ts
@@ -1,0 +1,64 @@
+import type { ShaderMotionParams } from '../shader-mount.js';
+import { type ShaderSizingParams, type ShaderSizingUniforms, sizingVariablesDeclaration } from '../shader-sizing.js';
+import { declarePI, declareRandom, declareRotate } from '../shader-utils.js';
+
+/**
+ * Basic pixelation effect.
+ */
+export const pixelateFragmentShader: string = `#version 300 es
+  precision mediump float;
+
+  uniform float u_time;
+  uniform vec2 u_resolution;
+  uniform float u_pixelRatio;
+
+  uniform sampler2D u_image;
+  uniform float u_image_aspect_ratio;
+
+  uniform float u_size_x;
+  uniform float u_size_y;
+
+  ${sizingVariablesDeclaration}
+  ${declarePI}
+  ${declareRotate}
+  ${declareRandom}
+
+  out vec4 fragColor;
+
+  float uvFrame(vec2 uv) {
+    return step(1e-3, uv.x) * step(uv.x, 1. - 1e-3) * step(1e-3, uv.y) * step(uv.y, 1. - 1e-3);
+  }
+
+  void main() {
+    vec2 imageUV = v_responsiveUV + .5;
+    float screenRatio = v_responsiveBoxGivenSize.x / v_responsiveBoxGivenSize.y;
+    float imageRatio = u_image_aspect_ratio;
+
+    vec2 ratio = (screenRatio > imageRatio) ? vec2(screenRatio / imageRatio, 1.) : vec2(1., imageRatio / screenRatio);
+
+    imageUV.y = 1. - imageUV.y;
+
+    imageUV -= .5;
+    imageUV *= ratio;
+    imageUV += .5;
+
+    float frame = uvFrame(imageUV);
+    if (frame < .05) discard;
+
+    vec2 size = vec2(u_size_x, u_size_y) * ratio;
+
+    fragColor = texture(u_image, ((floor((imageUV * u_resolution) / size) * size) + size * .5) / u_resolution);
+  }
+`;
+
+export interface PixelateUniforms extends ShaderSizingUniforms {
+  u_image: HTMLImageElement | string | null;
+  u_size_x: number;
+  u_size_y: number;
+}
+
+export interface PixelateParams extends ShaderSizingParams, ShaderMotionParams {
+  image?: HTMLImageElement | string | null;
+  sizeX?: number;
+  sizeY?: number;
+}


### PR DESCRIPTION
> [!NOTE]
> This branch is based off the `photo-filters` branch as it only makes sense with an image input. It'd probably be best to wait for that branch to be merged first. This branch can then be updated to match the patterns and conventions introduced in that branch and merged into `main`.

This PR adds a basic pixelation shader, nothing fancy, but I feel like it falls into the "common shaders" goal:

> Give designers a visual way to use common shaders in their designs

Does that seem reasonable or is it out-of-scope for the project?

Work still to be done:

- [ ] Fix the scaling. Currently, a `sizeX` value of `100` does result in 100px wide columns in the output.
- [ ] Align the grid to the centre of the image instead of the top-left.
- [ ] Add an optional higher-quality sampling method?