### PR TITLE
[DRAFT] Tartan

### DIFF
--- a/docs/registry.json
+++ b/docs/registry.json
@@ -275,6 +275,19 @@
           "type": "registry:component"
         }
       ]
+    },
+    {
+      "name": "tartan",
+      "type": "registry:component",
+      "title": "Tartan Example",
+      "description": "Tartan shader example.",
+      "dependencies": ["@paper-design/shaders-react"],
+      "files": [
+        {
+          "path": "registry/tartan-example.tsx",
+          "type": "registry:component"
+        }
+      ]
     }
   ]
 }

--- a/docs/registry/tartan-example.tsx
+++ b/docs/registry/tartan-example.tsx
@@ -1,0 +1,5 @@
+import { Tartan, type TartanProps } from '@paper-design/shaders-react';
+
+export function TartanExample(props: TartanProps) {
+  return <Tartan style={{ position: 'fixed', width: '100%', height: '100%' }} {...props} />;
+}

--- a/docs/src/app/tartan/layout.tsx
+++ b/docs/src/app/tartan/layout.tsx
@@ -1,0 +1,9 @@
+import { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Tartan Shader | Paper',
+};
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/docs/src/app/tartan/page.tsx
+++ b/docs/src/app/tartan/page.tsx
@@ -1,0 +1,149 @@
+'use client';
+
+import { BackButton } from '@/components/back-button';
+import { cleanUpLevaParams } from '@/helpers/clean-up-leva-params';
+import { toHsla } from '@/helpers/to-hsla';
+import { usePresetHighlight } from '@/helpers/use-preset-highlight';
+import { setParamsSafe, useResetLevaParams } from '@/helpers/use-reset-leva-params';
+import { type ShaderFit, ShaderFitOptions, tartanMeta } from '@paper-design/shaders';
+import { Tartan, tartanPresets } from '@paper-design/shaders-react';
+import { button, folder, useControls } from 'leva';
+import Link from 'next/link';
+
+/**
+ * You can copy/paste this example to use Tartan in your app
+ */
+const TartanExample = () => {
+  return <Tartan style={{ position: 'fixed', width: '100%', height: '100%' }} />;
+};
+
+/**
+ * This example has controls added so you can play with settings in the example app
+ */
+
+const defaults = tartanPresets[0].params;
+
+const TartanWithControls = () => {
+  const [{ count: stripeCount }, setStripeCount] = useControls(() => ({
+    Stripes: folder(
+      {
+        count: {
+          value: defaults.stripeColors.length,
+          min: 2,
+          max: tartanMeta.maxStripeCount,
+          step: 1,
+          order: 0,
+        },
+      },
+      { order: 1 }
+    ),
+  }));
+
+  const [colors, setColors] = useControls(() => {
+    const stripe: Record<string, { value: string; [key: string]: unknown }> = {};
+
+    for (let i = 0; i < stripeCount; i++) {
+      stripe[`color${i + 1}`] = {
+        value: defaults.stripeColors[i] ? toHsla(defaults.stripeColors[i]) : `hsla(${(40 * i) % 360}, 60%, 50%, 1)`,
+        order: 1 + i * 2,
+      };
+    }
+
+    return {
+      Stripes: folder(stripe),
+    };
+  }, [stripeCount]);
+
+  const [widths, setWidths] = useControls(() => {
+    const stripe: Record<string, { value: number; [key: string]: unknown }> = {};
+
+    for (let i = 0; i < stripeCount; i++) {
+      stripe[`width${i + 1}`] = {
+        value: defaults.stripeWidths[i],
+        min: 1,
+        max: 400,
+        step: 1,
+        order: 1 + i * 2 + 1,
+      };
+    }
+
+    return {
+      Stripes: folder(stripe),
+    };
+  }, [stripeCount]);
+
+  const [params, setParams] = useControls(() => {
+    return {
+      Transform: folder(
+        {
+          scale: { value: defaults.scale, min: 0.01, max: 4, order: 400 },
+          rotation: { value: defaults.rotation, min: 0, max: 360, order: 401 },
+          offsetX: { value: defaults.offsetX, min: -1, max: 1, order: 402 },
+          offsetY: { value: defaults.offsetY, min: -1, max: 1, order: 403 },
+        },
+        {
+          order: 2,
+          collapsed: false,
+        }
+      ),
+      Fit: folder(
+        {
+          fit: { value: defaults.fit, options: Object.keys(ShaderFitOptions) as ShaderFit[], order: 404 },
+          worldWidth: { value: 1000, min: 0, max: 5120, order: 405 },
+          worldHeight: { value: 500, min: 0, max: 5120, order: 406 },
+          originX: { value: defaults.originX, min: 0, max: 1, order: 407 },
+          originY: { value: defaults.originY, min: 0, max: 1, order: 408 },
+        },
+        {
+          order: 3,
+          collapsed: true,
+        }
+      ),
+    };
+  });
+
+  useControls(() => {
+    const presets = Object.fromEntries(
+      tartanPresets.map(({ name, params: { worldWidth, worldHeight, ...preset } }) => [
+        name,
+        button(() => {
+          const { stripeColors, stripeWidths, ...presetParams } = preset;
+          setStripeCount({ count: stripeColors.length });
+          setColors(
+            Object.fromEntries(stripeColors.map((value, i) => [`color${i + 1}`, toHsla(value)])) as unknown as Record<
+              string,
+              { value: string; [key: string]: unknown }
+            >
+          );
+          setWidths(Object.fromEntries(stripeWidths.map((value, i) => [`width${i + 1}`, value])));
+          setParamsSafe(params, setParams, presetParams);
+        }),
+      ])
+    );
+    return {
+      Presets: folder(presets, { order: -1 }),
+    };
+  });
+
+  // Reset to defaults on mount, so that Leva doesn't show values from other
+  // shaders when navigating (if two shaders have a color1 param for example)
+  useResetLevaParams(params, setParams, defaults);
+  usePresetHighlight(tartanPresets, params);
+  cleanUpLevaParams(params);
+
+  return (
+    <>
+      <Link href="/">
+        <BackButton />
+      </Link>
+      <Tartan
+        {...params}
+        stripeColors={Object.values(colors) as unknown as Array<string>}
+        stripeWidths={[...Object.values(widths), ...Array(9 - stripeCount).fill(0)]}
+        className="fixed size-full"
+      />
+    </>
+  );
+};
+
+export default TartanWithControls;

--- a/docs/src/app/tartan/page.tsx
+++ b/docs/src/app/tartan/page.tsx
@@ -74,6 +74,28 @@ const TartanWithControls = () => {
 
   const [params, setParams] = useControls(() => {
     return {
+      Parameters: folder(
+        {
+          weaveSize: {
+            value: defaults.weaveSize,
+            min: 1.0,
+            max: 10.0,
+            step: 0.25,
+            order: 0,
+          },
+          weaveStrength: {
+            value: defaults.weaveStrength,
+            min: 0.0,
+            max: 1.0,
+            step: 0.05,
+            order: 1,
+          },
+        },
+        {
+          order: 0,
+          collapsed: false,
+        }
+      ),
       Transform: folder(
         {
           scale: { value: defaults.scale, min: 0.01, max: 4, order: 400 },

--- a/docs/src/helpers/create-numbered-object.ts
+++ b/docs/src/helpers/create-numbered-object.ts
@@ -1,0 +1,36 @@
+/**
+ * Creates an object with up to 9 properties, each named using a prefix and a number.
+ *
+ * @example
+ * const result = createNumberedObject('foo', 3, i => `bar${i + 1}`);
+ * console.log(result); // { foo1: 'bar1', foo2: 'bar2', foo3: 'bar3' }
+ */
+export const createNumberedObject = <Prefix extends string, Count extends 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9, Value>(
+  prefix: Prefix,
+  count: Count,
+  mapFn: (i: number) => Value
+) => {
+  const result = new Map<string, Value>();
+  for (let i = 0; i < count; i++) result.set(`${prefix}${i + 1}`, mapFn(i));
+  return Object.fromEntries(result) as Record<`${Prefix}${Range<Count>}`, Value>;
+};
+
+type Range<Count extends 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9> = Count extends 1
+  ? 1
+  : Count extends 2
+    ? 1 | 2
+    : Count extends 3
+      ? 1 | 2 | 3
+      : Count extends 4
+        ? 1 | 2 | 3 | 4
+        : Count extends 5
+          ? 1 | 2 | 3 | 4 | 5
+          : Count extends 6
+            ? 1 | 2 | 3 | 4 | 5 | 6
+            : Count extends 7
+              ? 1 | 2 | 3 | 4 | 5 | 6 | 7
+              : Count extends 8
+                ? 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8
+                : Count extends 9
+                  ? 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9
+                  : never;

--- a/docs/src/helpers/get-values-sorted-by-key.ts
+++ b/docs/src/helpers/get-values-sorted-by-key.ts
@@ -1,0 +1,12 @@
+/**
+ * Returns an array of values from an object ordered by their keys.
+ *
+ * @example
+ * const obj = { foo2: 'dog', foo1: 'pig', foo3: 'cat' };
+ * const results = getValuesFromNumberedObject(obj);
+ * console.log(results); // ['pig', 'dog', 'cat']
+ */
+export const getValuesSortedByKey = <T extends object>(obj: T): Array<T[keyof T]> =>
+  Object.entries(obj)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([, value]) => value);

--- a/docs/src/home-shaders.ts
+++ b/docs/src/home-shaders.ts
@@ -63,6 +63,8 @@ import {
   staticMeshGradientPresets,
   StaticRadialGradient,
   staticRadialGradientPresets,
+  Tartan,
+  tartanPresets,
 } from '@paper-design/shaders-react';
 import { StaticImageData } from 'next/image';
 import TextureTest from './app/texture-test/page';
@@ -229,5 +231,11 @@ export const homeShaders = [
     ShaderComponent: GodRays,
     image: godRaysImg,
     shaderConfig: { ...godRaysPresets[0].params, speed: 2, scale: 0.5, offsetY: -0.5 },
+  },
+  {
+    name: 'tartan',
+    url: '/tartan',
+    ShaderComponent: Tartan,
+    shaderConfig: { ...tartanPresets[0].params },
   },
 ] satisfies HomeShaderConfig[];

--- a/packages/shaders-react/src/index.ts
+++ b/packages/shaders-react/src/index.ts
@@ -87,6 +87,10 @@ export { StaticRadialGradient, staticRadialGradientPresets } from './shaders/sta
 export type { StaticRadialGradientProps } from './shaders/static-radial-gradient.js';
 export type { StaticRadialGradientUniforms, StaticRadialGradientParams } from '@paper-design/shaders';
 
+export { Tartan, tartanPresets } from './shaders/tartan.js';
+export type { TartanProps } from './shaders/tartan.js';
+export type { TartanUniforms, TartanParams } from '@paper-design/shaders';
+
 export { isPaperShaderElement, getShaderColorFromString } from '@paper-design/shaders';
 export type { PaperShaderElement, ShaderFit, ShaderSizingParams, ShaderSizingUniforms } from '@paper-design/shaders';
 

--- a/packages/shaders-react/src/shaders/tartan.tsx
+++ b/packages/shaders-react/src/shaders/tartan.tsx
@@ -1,13 +1,13 @@
-import { memo } from 'react';
 import {
   defaultPatternSizing,
   getShaderColorFromString,
   ShaderFitOptions,
   type ShaderPreset,
-  tartanFragmentShader,
   type TartanParams,
   type TartanUniforms,
+  tartanFragmentShader,
 } from '@paper-design/shaders';
+import { memo } from 'react';
 import { colorPropsAreEqual } from '../color-props-are-equal.js';
 import { type ShaderComponentProps, ShaderMount } from '../shader-mount.js';
 
@@ -19,8 +19,10 @@ export const defaultPreset: TartanPreset = {
   name: 'Default',
   params: {
     ...defaultPatternSizing,
-    stripeColors: ['#19600b', '#aa0909', '#19600b', '#041a07', '#c3a855', '#041a07'],
+    stripeColors: ['#19600b', '#aa0909', '#19600b', '#083a0f', '#c3a855', '#083a0f'],
     stripeWidths: [30, 4, 40, 30, 1, 30],
+    weaveSize: 3.0,
+    weaveStrength: 0.25,
   },
 };
 
@@ -30,6 +32,8 @@ export const Tartan: React.FC<TartanProps> = memo(function TartanImpl({
   // Own props
   stripeColors = defaultPreset.params.stripeColors,
   stripeWidths = defaultPreset.params.stripeWidths,
+  weaveSize = defaultPreset.params.weaveSize,
+  weaveStrength = defaultPreset.params.weaveStrength,
 
   // Sizing props
   fit = defaultPreset.params.fit,
@@ -48,6 +52,8 @@ export const Tartan: React.FC<TartanProps> = memo(function TartanImpl({
     u_stripeColors: stripeColors.map(getShaderColorFromString),
     u_stripeWidths: stripeWidths,
     u_stripeCount: stripeColors.length,
+    u_weaveSize: weaveSize,
+    u_weaveStrength: weaveStrength,
 
     // Sizing uniforms
     u_fit: ShaderFitOptions[fit],

--- a/packages/shaders-react/src/shaders/tartan.tsx
+++ b/packages/shaders-react/src/shaders/tartan.tsx
@@ -1,0 +1,65 @@
+import { memo } from 'react';
+import {
+  defaultPatternSizing,
+  getShaderColorFromString,
+  ShaderFitOptions,
+  type ShaderPreset,
+  tartanFragmentShader,
+  type TartanParams,
+  type TartanUniforms,
+} from '@paper-design/shaders';
+import { colorPropsAreEqual } from '../color-props-are-equal.js';
+import { type ShaderComponentProps, ShaderMount } from '../shader-mount.js';
+
+export interface TartanProps extends ShaderComponentProps, TartanParams {}
+
+type TartanPreset = ShaderPreset<TartanParams>;
+
+export const defaultPreset: TartanPreset = {
+  name: 'Default',
+  params: {
+    ...defaultPatternSizing,
+    stripeColors: ['#19600b', '#aa0909', '#19600b', '#041a07', '#c3a855', '#041a07'],
+    stripeWidths: [30, 4, 40, 30, 1, 30],
+  },
+};
+
+export const tartanPresets: TartanPreset[] = [defaultPreset];
+
+export const Tartan: React.FC<TartanProps> = memo(function TartanImpl({
+  // Own props
+  stripeColors = defaultPreset.params.stripeColors,
+  stripeWidths = defaultPreset.params.stripeWidths,
+
+  // Sizing props
+  fit = defaultPreset.params.fit,
+  scale = defaultPreset.params.scale,
+  rotation = defaultPreset.params.rotation,
+  originX = defaultPreset.params.originX,
+  originY = defaultPreset.params.originY,
+  offsetX = defaultPreset.params.offsetX,
+  offsetY = defaultPreset.params.offsetY,
+  worldWidth = defaultPreset.params.worldWidth,
+  worldHeight = defaultPreset.params.worldHeight,
+  ...props
+}: TartanProps) {
+  const uniforms = {
+    // Own uniforms
+    u_stripeColors: stripeColors.map(getShaderColorFromString),
+    u_stripeWidths: stripeWidths,
+    u_stripeCount: stripeColors.length,
+
+    // Sizing uniforms
+    u_fit: ShaderFitOptions[fit],
+    u_scale: scale,
+    u_rotation: rotation,
+    u_offsetX: offsetX,
+    u_offsetY: offsetY,
+    u_originX: originX,
+    u_originY: originY,
+    u_worldWidth: worldWidth,
+    u_worldHeight: worldHeight,
+  } satisfies TartanUniforms;
+
+  return <ShaderMount {...props} fragmentShader={tartanFragmentShader} uniforms={uniforms} />;
+}, colorPropsAreEqual);

--- a/packages/shaders-react/src/shaders/tartan.tsx
+++ b/packages/shaders-react/src/shaders/tartan.tsx
@@ -27,7 +27,19 @@ export const defaultPreset: TartanPreset = {
   },
 };
 
-export const tartanPresets: TartanPreset[] = [defaultPreset];
+export const colorfulPreset: TartanPreset = {
+  name: 'Colorful',
+  params: {
+    ...defaultPatternSizing,
+    stripeCount: 9,
+    stripeColors: ['#cc3333', '#cc9933', '#99cc33', '#33cc33', '#33cc99', '#3399cc', '#3333cc', '#9933cc', '#cc3399'],
+    stripeWidths: [1, 2, 2, 2, 2, 2, 2, 2, 1],
+    weaveSize: 6.0,
+    weaveStrength: 0.25,
+  },
+};
+
+export const tartanPresets: TartanPreset[] = [defaultPreset, colorfulPreset];
 
 export const Tartan: React.FC<TartanProps> = memo(function TartanImpl({
   // Own props

--- a/packages/shaders-react/src/shaders/tartan.tsx
+++ b/packages/shaders-react/src/shaders/tartan.tsx
@@ -19,8 +19,9 @@ export const defaultPreset: TartanPreset = {
   name: 'Default',
   params: {
     ...defaultPatternSizing,
+    stripeCount: 6,
     stripeColors: ['#19600b', '#aa0909', '#19600b', '#083a0f', '#c3a855', '#083a0f'],
-    stripeWidths: [30, 4, 40, 30, 1, 30],
+    stripeWidths: [15, 2, 20, 15, 1, 15],
     weaveSize: 3.0,
     weaveStrength: 0.25,
   },
@@ -30,6 +31,7 @@ export const tartanPresets: TartanPreset[] = [defaultPreset];
 
 export const Tartan: React.FC<TartanProps> = memo(function TartanImpl({
   // Own props
+  stripeCount = defaultPreset.params.stripeCount,
   stripeColors = defaultPreset.params.stripeColors,
   stripeWidths = defaultPreset.params.stripeWidths,
   weaveSize = defaultPreset.params.weaveSize,
@@ -49,9 +51,9 @@ export const Tartan: React.FC<TartanProps> = memo(function TartanImpl({
 }: TartanProps) {
   const uniforms = {
     // Own uniforms
+    u_stripeCount: stripeCount,
     u_stripeColors: stripeColors.map(getShaderColorFromString),
     u_stripeWidths: stripeWidths,
-    u_stripeCount: stripeColors.length,
     u_weaveSize: weaveSize,
     u_weaveStrength: weaveStrength,
 

--- a/packages/shaders/src/index.ts
+++ b/packages/shaders/src/index.ts
@@ -171,6 +171,9 @@ export {
   type StaticRadialGradientUniforms,
 } from './shaders/static-radial-gradient.js';
 
+// ----- Tartan ----- //
+export { tartanMeta, tartanFragmentShader, type TartanParams, type TartanUniforms } from './shaders/tartan.js';
+
 // ----- Utils ----- //
 export { getShaderColorFromString } from './get-shader-color-from-string.js';
 export { getShaderNoiseTexture } from './get-shader-noise-texture.js';

--- a/packages/shaders/src/shaders/tartan.ts
+++ b/packages/shaders/src/shaders/tartan.ts
@@ -113,6 +113,7 @@ export interface TartanUniforms extends ShaderSizingUniforms {
 }
 
 export interface TartanParams extends ShaderSizingParams {
+  stripeCount?: number;
   stripeColors?: string[];
   stripeWidths?: number[];
   weaveSize?: number;

--- a/packages/shaders/src/shaders/tartan.ts
+++ b/packages/shaders/src/shaders/tartan.ts
@@ -10,8 +10,10 @@ export const tartanMeta = {
  *
  * Uniforms:
  * - u_stripeCount: number of stripes in the pattern (float used as integer)
- * - u_stripeColors (vec4[])
- * - u_stripeWidths (mat3)
+ * - u_stripeColors: array of stripe colors (vec4[])
+ * - u_stripeWidths: array of stripe widths (mat3 used as an array)
+ * - u_weaveSize: width of thread used in the weave texture (float)
+ * - u_weaveStrength: strength of weave texture (float)
  *
  */
 
@@ -22,13 +24,27 @@ precision mediump float;
 uniform float u_stripeCount;
 uniform vec4[${tartanMeta.maxStripeCount}] u_stripeColors;
 uniform mat3 u_stripeWidths;
+uniform float u_weaveSize;
+uniform float u_weaveStrength;
 
 ${sizingVariablesDeclaration}
 
 out vec4 fragColor;
 
 void main() {
-  vec2 uv = v_patternUV * 100.0;
+  vec2 uv = (v_patternUV * 100.0) / u_weaveSize;
+
+  vec2 weave = mod(
+      vec2(
+          uv.x + floor(mod(uv.y, 4.0)),
+          uv.y + floor(mod(uv.x, 4.0)) - 2.0
+      ),
+      4.0
+  );
+
+  // Color
+
+  vec4 verticalColor, horizontalColor;
 
   float[${tartanMeta.maxStripeCount}] cumulativeWidths;
 
@@ -41,36 +57,50 @@ void main() {
     totalWidth += width;
   }
 
-  vec2 cell = mod(
-    uv.xy,
-    totalWidth * 2.0
+  vec2 stripe = mod(
+      uv,
+      totalWidth * 2.0
   ) - totalWidth;
 
-  // Color of vertical stripe.
-  vec4 verticalColor;
   for (int i = 0; i < ${tartanMeta.maxStripeCount}; i++) {
     if (i >= int(u_stripeCount)) break;
     verticalColor = u_stripeColors[i];
-    if (abs(cell.x) < cumulativeWidths[i]) {
+    if (abs(stripe.x) < cumulativeWidths[i]) {
       break;
     }
   }
 
-  // Color of horizontal stripe.
-  vec4 horizontalColor;
   for (int i = 0; i < ${tartanMeta.maxStripeCount}; i++) {
     if (i >= int(u_stripeCount)) break;
     horizontalColor = u_stripeColors[i];
-    if (abs(cell.y) < cumulativeWidths[i]) {
+    if (abs(stripe.y) < cumulativeWidths[i]) {
       break;
     }
   }
 
-  // Weave pattern.
-  // See: https://en.wikipedia.org/wiki/Tartan#Weaving_construction
-  float a = mod(uv.x + mod(floor(uv.y), 4.0), 4.0) / 4.0;
+  fragColor = mix(
+      verticalColor,
+      horizontalColor,
+      1.0 - step(2.0, weave.x)
+  );
 
-  fragColor = a < 0.5 ? verticalColor : horizontalColor;
+  // Texture
+
+  vec2 brightness = vec2(0.0);
+
+  brightness += smoothstep(0.0, 0.5, weave);
+  brightness -= smoothstep(1.5, 2.0, weave);
+
+  brightness += smoothstep(2.0, 2.25, weave);
+  brightness -= smoothstep(2.75, 3.0, weave);
+
+  brightness += smoothstep(3.0, 3.25, weave);
+  brightness -= smoothstep(3.75, 4.0, weave);
+
+  brightness *= u_weaveStrength;
+  brightness += 1.0 - u_weaveStrength;
+
+  fragColor = mix(vec4(0.0, 0.0, 0.0, 1.0), fragColor, brightness.x * brightness.y);
 }
 `;
 
@@ -78,9 +108,13 @@ export interface TartanUniforms extends ShaderSizingUniforms {
   u_stripeColors: vec4[];
   u_stripeWidths: number[];
   u_stripeCount: number;
+  u_weaveSize: number;
+  u_weaveStrength: number;
 }
 
 export interface TartanParams extends ShaderSizingParams {
   stripeColors?: string[];
   stripeWidths?: number[];
+  weaveSize?: number;
+  weaveStrength?: number;
 }

--- a/packages/shaders/src/shaders/tartan.ts
+++ b/packages/shaders/src/shaders/tartan.ts
@@ -1,0 +1,86 @@
+import { sizingVariablesDeclaration, type ShaderSizingParams, type ShaderSizingUniforms } from '../shader-sizing.js';
+import type { vec4 } from '../types.js';
+
+export const tartanMeta = {
+  maxStripeCount: 9,
+} as const;
+
+/**
+ * Tartan patterns
+ *
+ * Uniforms:
+ * - u_stripeCount: number of stripes in the pattern (float used as integer)
+ * - u_stripeColors (vec4[])
+ * - u_stripeWidths (mat3)
+ *
+ */
+
+// language=GLSL
+export const tartanFragmentShader: string = `#version 300 es
+precision mediump float;
+
+uniform float u_stripeCount;
+uniform vec4[${tartanMeta.maxStripeCount}] u_stripeColors;
+uniform mat3 u_stripeWidths;
+
+${sizingVariablesDeclaration}
+
+out vec4 fragColor;
+
+void main() {
+  vec2 uv = v_patternUV * 100.0;
+
+  float[${tartanMeta.maxStripeCount}] cumulativeWidths;
+
+  float totalWidth = 0.0;
+
+  for (int i = 0; i < ${tartanMeta.maxStripeCount}; i++) {
+    if (i >= int(u_stripeCount)) break;
+    float width = float(u_stripeWidths[int(i / 3)][int(i % 3)]);
+    cumulativeWidths[i] = (i == 0 ? 0.0 : cumulativeWidths[i - 1]) + width;
+    totalWidth += width;
+  }
+
+  vec2 cell = mod(
+    uv.xy,
+    totalWidth * 2.0
+  ) - totalWidth;
+
+  // Color of vertical stripe.
+  vec4 verticalColor;
+  for (int i = 0; i < ${tartanMeta.maxStripeCount}; i++) {
+    if (i >= int(u_stripeCount)) break;
+    verticalColor = u_stripeColors[i];
+    if (abs(cell.x) < cumulativeWidths[i]) {
+      break;
+    }
+  }
+
+  // Color of horizontal stripe.
+  vec4 horizontalColor;
+  for (int i = 0; i < ${tartanMeta.maxStripeCount}; i++) {
+    if (i >= int(u_stripeCount)) break;
+    horizontalColor = u_stripeColors[i];
+    if (abs(cell.y) < cumulativeWidths[i]) {
+      break;
+    }
+  }
+
+  // Weave pattern.
+  // See: https://en.wikipedia.org/wiki/Tartan#Weaving_construction
+  float a = mod(uv.x + mod(floor(uv.y), 4.0), 4.0) / 4.0;
+
+  fragColor = a < 0.5 ? verticalColor : horizontalColor;
+}
+`;
+
+export interface TartanUniforms extends ShaderSizingUniforms {
+  u_stripeColors: vec4[];
+  u_stripeWidths: number[];
+  u_stripeCount: number;
+}
+
+export interface TartanParams extends ShaderSizingParams {
+  stripeColors?: string[];
+  stripeWidths?: number[];
+}


### PR DESCRIPTION
## Changes

Adds a new tartan shader.

The pattern adheres to the typical traditional tartan patterns where the "sett" is repeated in reverse and both the "warp" and the "weft" are the same. This is to say, the pattern is symmetrical both horizontally and vertically. See [the Wikipedia article](https://en.wikipedia.org/wiki/Tartan#Weaving_construction) for details.

## Work still to be done

- [x] Fix issue with extra width controls not being added to the Leva controls.
- [x] Add a weave texture. It'd be nicer if the fabric pattern was subtly applied to the whole image (even in areas of solid colour).
- [ ] Fix pixelation issues.
- [x] Replace `uniform mat3 u_stripeWidths` with `uniform float[9] u_stripeWidths`? This appears to be a limitation of `ShaderMount`.
- [ ] Add preview image.
- [ ] Add more presets.
- [x] Fix TypeScript type assertions for `colors` in `docs/src/app/tartan/page.tsx`. These have been added because the return type of Leva's `useControls` appears to be typed incorrectly.
- [ ] Rename to "Static Tartan" to match the naming convention already in use for other static shaders.

### Pixelation issues

The current sizing prevents the pattern from being aligned with the pixel grid (see images below). Two options to explore:

1. Do the sizing in the fragment shader as is done in the dithering shader.
2. Use anti-aliasing. (This is probably preferable if a weave texture is going to be applied anyway.)

Shadertoy (using `vec2 uv = (fragCoord.xy - iResolution.xy * 0.5)`):

<img width="397" height="346" alt="image" src="https://github.com/user-attachments/assets/09d990c3-9b34-494f-9d3d-9943a936b492" />

Paper shaders (using `vec2 uv = v_patternUV * 100.0`):

<img width="262" height="245" alt="image" src="https://github.com/user-attachments/assets/0cb4c807-d53c-4c9d-b611-89e2a4cc7d72" />
