### PR TITLE
Replace default image with transparent px

### DIFF
--- a/packages/shaders-react/src/shaders/fluted-glass.tsx
+++ b/packages/shaders-react/src/shaders/fluted-glass.tsx
@@ -10,6 +10,7 @@ import {
   GlassDistortionShapes,
   GlassGridShapes,
 } from '@paper-design/shaders';
+import { transparentPixel } from '../transparent-pixe.js';
 
 export interface FlutedGlassProps extends ShaderComponentProps, FlutedGlassParams {}
 
@@ -115,7 +116,7 @@ export const FlutedGlass: React.FC<FlutedGlassProps> = memo(function FlutedGlass
   // Own props
   speed = defaultPreset.params.speed,
   frame = defaultPreset.params.frame,
-  image = defaultPreset.params.image,
+  image = transparentPixel,
   count = defaultPreset.params.count,
   angle = defaultPreset.params.angle,
   distortion = defaultPreset.params.distortion,

--- a/packages/shaders-react/src/shaders/image-dithering.tsx
+++ b/packages/shaders-react/src/shaders/image-dithering.tsx
@@ -11,6 +11,7 @@ import {
   defaultObjectSizing,
   DitheringTypes,
 } from '@paper-design/shaders';
+import { transparentPixel } from '../transparent-pixe.js';
 
 export interface ImageDitheringProps extends ShaderComponentProps, ImageDitheringParams {}
 
@@ -95,7 +96,7 @@ export const ImageDithering: React.FC<ImageDitheringProps> = memo(function Image
   colorFront = defaultPreset.params.colorFront,
   colorBack = defaultPreset.params.colorBack,
   colorHighlight = defaultPreset.params.colorHighlight,
-  image = defaultPreset.params.image,
+  image = transparentPixel,
   type = defaultPreset.params.type,
   pxSize = defaultPreset.params.pxSize,
   colorSteps = defaultPreset.params.colorSteps,

--- a/packages/shaders-react/src/shaders/paper-texture.tsx
+++ b/packages/shaders-react/src/shaders/paper-texture.tsx
@@ -11,6 +11,7 @@ import {
   type PaperTextureUniforms,
   type ShaderPreset,
 } from '@paper-design/shaders';
+import { transparentPixel } from '../transparent-pixe.js';
 
 export interface PaperTextureProps extends ShaderComponentProps, PaperTextureParams {}
 
@@ -129,7 +130,7 @@ export const PaperTexture: React.FC<PaperTextureProps> = memo(function PaperText
   frame = defaultPreset.params.frame,
   colorFront = defaultPreset.params.colorFront,
   colorBack = defaultPreset.params.colorBack,
-  image = defaultPreset.params.image,
+  image = transparentPixel,
   contrast = defaultPreset.params.contrast,
   roughness = defaultPreset.params.roughness,
   fiber = defaultPreset.params.fiber,

--- a/packages/shaders-react/src/shaders/water.tsx
+++ b/packages/shaders-react/src/shaders/water.tsx
@@ -10,6 +10,7 @@ import {
   type ShaderPreset,
   defaultObjectSizing,
 } from '@paper-design/shaders';
+import { transparentPixel } from '../transparent-pixe.js';
 
 export interface WaterProps extends ShaderComponentProps, WaterParams {}
 
@@ -102,7 +103,7 @@ export const Water: React.FC<WaterProps> = memo(function WaterImpl({
   frame = defaultPreset.params.frame,
   colorBack = defaultPreset.params.colorBack,
   colorHighlight = defaultPreset.params.colorHighlight,
-  image = defaultPreset.params.image,
+  image = transparentPixel,
   highlights = defaultPreset.params.highlights,
   layering = defaultPreset.params.layering,
   waves = defaultPreset.params.waves,

--- a/packages/shaders-react/src/transparent-pixe.ts
+++ b/packages/shaders-react/src/transparent-pixe.ts
@@ -1,0 +1,1 @@
+export const transparentPixel = 'data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==';


### PR DESCRIPTION
To aid in the "delete image" flow in app this pull request replaces the default value for the `image` prop to be a transparent pixel instead of the default image. This doesn't change the default preset and how it should be used on the paper shaders site or paper app.