### PR TITLE
Fix race condition when updating uniforms

### DIFF
--- a/packages/shaders-react/src/shader-mount.tsx
+++ b/packages/shaders-react/src/shader-mount.tsx
@@ -148,12 +148,23 @@ export const ShaderMount: React.FC<ShaderMountProps> = forwardRef<PaperShaderEle
 
     // Uniforms
     useEffect(() => {
+      let isStale = false;
+
       const updateUniforms = async () => {
         const uniforms = await processUniforms(uniformsProp);
-        shaderMountRef.current?.setUniforms(uniforms);
+
+        if (!isStale) {
+          // We only use the freshest uniforms otherwise we can get into race conditions
+          // if some uniforms (images!) take longer to load in subsequent effect runs.
+          shaderMountRef.current?.setUniforms(uniforms);
+        }
       };
 
       updateUniforms();
+
+      return () => {
+        isStale = true;
+      };
     }, [uniformsProp, isInitialized]);
 
     // Speed


### PR DESCRIPTION
When implementing the new image upload I ran into this issue, being on a mobile network and images not being cached also exacerbated the issue. As I was here I saw an improvement for making uniform processing synchronous if there were no images being waited on.