### PR TITLE
Add shouldSuspend prop to heatmap shader component

### DIFF
--- a/docs/src/app/test/page.tsx
+++ b/docs/src/app/test/page.tsx
@@ -8,7 +8,6 @@ export default function TestPage() {
       <Heatmap
         {...heatmapPresets.find((preset) => preset.name === 'Default')?.params}
         style={{ width: 600, height: 600 }}
-        shouldSuspend
       />
     </div>
   );

--- a/docs/src/app/test/page.tsx
+++ b/docs/src/app/test/page.tsx
@@ -8,6 +8,7 @@ export default function TestPage() {
       <Heatmap
         {...heatmapPresets.find((preset) => preset.name === 'Default')?.params}
         style={{ width: 600, height: 600 }}
+        shouldSuspend
       />
     </div>
   );

--- a/packages/shaders-react/src/shaders/heatmap.tsx
+++ b/packages/shaders-react/src/shaders/heatmap.tsx
@@ -11,10 +11,15 @@ import {
   toProcessedHeatmap,
 } from '@paper-design/shaders';
 
-import { preload } from 'react-dom';
 import { transparentPixel } from '../transparent-pixel.js';
+import { suspend } from '../suspend.js';
 
-export interface HeatmapProps extends ShaderComponentProps, HeatmapParams {}
+export interface HeatmapProps extends ShaderComponentProps, HeatmapParams {
+  /**
+   * Suspends the component when the image is being processed.
+   */
+  shouldSuspend?: boolean;
+}
 
 export type HeatmapPreset = ShaderPreset<HeatmapParams>;
 
@@ -67,6 +72,7 @@ export const Heatmap: React.FC<HeatmapProps> = memo(function HeatmapImpl({
   outerGlow = defaultPreset.params.outerGlow,
   colorBack = defaultPreset.params.colorBack,
   colors = defaultPreset.params.colors,
+  shouldSuspend = false,
 
   // Sizing props
   fit = defaultPreset.params.fit,
@@ -81,14 +87,28 @@ export const Heatmap: React.FC<HeatmapProps> = memo(function HeatmapImpl({
   worldWidth = defaultPreset.params.worldWidth,
   ...props
 }: HeatmapProps) {
-  const [processedImage, setProcessedImage] = useState<string>(transparentPixel);
-
   const imageUrl = typeof image === 'string' ? image : image.src;
-  preload(imageUrl, { as: 'image', crossOrigin: 'anonymous', fetchPriority: 'high' });
+  const [processedStateImage, setProcessedStateImage] = useState<string>(transparentPixel);
+
+  let processedImage: string;
+
+  if (shouldSuspend) {
+    processedImage = suspend(
+      (): Promise<string> => toProcessedHeatmap(imageUrl).then((result) => URL.createObjectURL(result.blob)),
+      [imageUrl]
+    );
+  } else {
+    processedImage = processedStateImage;
+  }
 
   useLayoutEffect(() => {
+    if (shouldSuspend) {
+      // Skip doing work in the effect as it's been handled by suspense.
+      return;
+    }
+
     if (!imageUrl) {
-      setProcessedImage(transparentPixel);
+      setProcessedStateImage(transparentPixel);
       return;
     }
 
@@ -98,7 +118,7 @@ export const Heatmap: React.FC<HeatmapProps> = memo(function HeatmapImpl({
     toProcessedHeatmap(imageUrl).then((result) => {
       if (current) {
         url = URL.createObjectURL(result.blob);
-        setProcessedImage(url);
+        setProcessedStateImage(url);
       }
     });
 
@@ -106,7 +126,7 @@ export const Heatmap: React.FC<HeatmapProps> = memo(function HeatmapImpl({
       current = false;
       URL.revokeObjectURL(url);
     };
-  }, [imageUrl]);
+  }, [imageUrl, shouldSuspend]);
 
   const uniforms = useMemo(
     () => ({

--- a/packages/shaders-react/src/suspend.tsx
+++ b/packages/shaders-react/src/suspend.tsx
@@ -1,0 +1,74 @@
+/**
+ * A cut down version of suspend-react.
+ * When paper-shaders only supports React 19+ we can use the use hook instead.
+ */
+
+type Tuple<T = any> = [T] | T[];
+type Await<T> = T extends Promise<infer V> ? V : never;
+type Cache<Keys extends Tuple<unknown>> = {
+  promise: Promise<unknown>;
+  keys: Keys;
+  error?: any;
+  response?: unknown;
+};
+
+const isPromise = (promise: any): promise is Promise<unknown> =>
+  typeof promise === 'object' && typeof (promise as Promise<any>).then === 'function';
+
+const globalCache: Cache<Tuple<unknown>>[] = [];
+
+function shallowEqualArrays(arrA: any[], arrB: any[]) {
+  if (arrA === arrB) return true;
+  if (!arrA || !arrB) return false;
+  const len = arrA.length;
+  if (arrB.length !== len) return false;
+  for (let i = 0; i < len; i++) if (arrA[i] !== arrB[i]) return false;
+  return true;
+}
+
+function query<Keys extends Tuple<unknown>, Fn extends (...keys: Keys) => Promise<unknown>>(
+  fn: Fn | Promise<unknown>,
+  keys: Keys = null as unknown as Keys
+) {
+  // If no keys were given, the function is the key
+  if (keys === null) keys = [fn] as unknown as Keys;
+
+  for (const entry of globalCache) {
+    // Find a match
+    if (shallowEqualArrays(keys, entry.keys)) {
+      // If an error occurred, throw
+      if (Object.prototype.hasOwnProperty.call(entry, 'error')) throw entry.error;
+      // If a response was successful, return
+      if (Object.prototype.hasOwnProperty.call(entry, 'response')) {
+        return entry.response as Await<ReturnType<Fn>>;
+      }
+      // If the promise is still unresolved, throw
+      throw entry.promise;
+    }
+  }
+
+  // The request is new or has changed.
+  const entry: Cache<Keys> = {
+    keys,
+    promise:
+      // Execute the promise
+      (isPromise(fn) ? fn : fn(...keys))
+        // When it resolves, store its value
+        .then((response) => {
+          entry.response = response;
+        })
+        // Store caught errors, they will be thrown in the render-phase to bubble into an error-bound
+        .catch((error) => (entry.error = error)),
+  };
+  // Register the entry
+  globalCache.push(entry);
+  // And throw the promise, this yields control back to React
+  throw entry.promise;
+}
+
+const suspend = <Keys extends Tuple<unknown>, Fn extends (...keys: Keys) => Promise<unknown>>(
+  fn: Fn | Promise<unknown>,
+  keys?: Keys
+): Await<ReturnType<Fn>> => query(fn, keys);
+
+export { suspend };


### PR DESCRIPTION
This pull requests adds a `shouldSuspend` prop to the heatmap shader component. It uses a forked version of suspend-react that cuts it down to the bare minimum we need. When we move to React 19+ only we can effectively replace its usage with the `use` hook.