### PR TITLE
Remove image from image shader presets

### DIFF
--- a/packages/shaders-react/src/shaders/fluted-glass.tsx
+++ b/packages/shaders-react/src/shaders/fluted-glass.tsx
@@ -5,25 +5,23 @@ import {
   ShaderFitOptions,
   type FlutedGlassUniforms,
   type FlutedGlassParams,
-  type ShaderPreset,
   defaultObjectSizing,
   GlassDistortionShapes,
   GlassGridShapes,
+  type ImageShaderPreset,
 } from '@paper-design/shaders';
 
 export interface FlutedGlassProps extends ShaderComponentProps, FlutedGlassParams {}
 
-type FlutedGlassPreset = ShaderPreset<FlutedGlassParams>;
+type FlutedGlassPreset = ImageShaderPreset<FlutedGlassParams>;
 
 export const defaultPreset: FlutedGlassPreset = {
   name: 'Default',
   params: {
     ...defaultObjectSizing,
     fit: 'cover',
-    // scale: 0.95,
     speed: 0,
     frame: 0,
-    image: 'https://shaders.paper.design/images/image-filters/0018.webp',
     count: 80,
     angle: 0,
     distortionShape: 'lens',
@@ -46,7 +44,6 @@ export const wavesPreset: FlutedGlassPreset = {
     fit: 'cover',
     speed: 0,
     frame: 0,
-    image: 'https://shaders.paper.design/images/image-filters/0018.webp',
     count: 20,
     angle: 0,
     distortionShape: 'contour',
@@ -70,7 +67,6 @@ export const irregularPreset: FlutedGlassPreset = {
     scale: 4,
     speed: 0,
     frame: 0,
-    image: 'https://shaders.paper.design/images/image-filters/0018.webp',
     count: 32,
     angle: 150,
     distortionShape: 'facete',
@@ -93,7 +89,6 @@ export const foldsPreset: FlutedGlassPreset = {
     fit: 'cover',
     speed: 0,
     frame: 0,
-    image: 'https://shaders.paper.design/images/image-filters/0018.webp',
     count: 50,
     angle: 0,
     distortionShape: 'cascade',
@@ -115,7 +110,7 @@ export const FlutedGlass: React.FC<FlutedGlassProps> = memo(function FlutedGlass
   // Own props
   speed = defaultPreset.params.speed,
   frame = defaultPreset.params.frame,
-  image = defaultPreset.params.image,
+  image = 'https://shaders.paper.design/images/image-filters/0018.webp',
   count = defaultPreset.params.count,
   angle = defaultPreset.params.angle,
   distortion = defaultPreset.params.distortion,

--- a/packages/shaders-react/src/shaders/heatmap.tsx
+++ b/packages/shaders-react/src/shaders/heatmap.tsx
@@ -6,9 +6,9 @@ import {
   ShaderFitOptions,
   type HeatmapUniforms,
   type HeatmapParams,
-  type ShaderPreset,
   defaultObjectSizing,
   toProcessedHeatmap,
+  type ImageShaderPreset,
 } from '@paper-design/shaders';
 
 import { transparentPixel } from '../transparent-pixel.js';
@@ -21,7 +21,7 @@ export interface HeatmapProps extends ShaderComponentProps, HeatmapParams {
   suspendWhenProcessingImage?: boolean;
 }
 
-export type HeatmapPreset = ShaderPreset<HeatmapParams>;
+export type HeatmapPreset = ImageShaderPreset<HeatmapParams>;
 
 export const defaultPreset: HeatmapPreset = {
   name: 'Default',
@@ -30,7 +30,6 @@ export const defaultPreset: HeatmapPreset = {
     scale: 0.75,
     speed: 1,
     frame: 0,
-    image: 'https://shaders.paper.design/images/image-filters/0019.webp',
     contour: 0.5,
     angle: 0,
     noise: 0,
@@ -48,7 +47,6 @@ export const sepiaPreset: HeatmapPreset = {
     scale: 0.75,
     speed: 0.5,
     frame: 0,
-    image: 'https://shaders.paper.design/images/image-filters/0019.webp',
     contour: 0.5,
     angle: 0,
     noise: 0.75,
@@ -65,6 +63,7 @@ export const Heatmap: React.FC<HeatmapProps> = memo(function HeatmapImpl({
   // Own props
   speed = defaultPreset.params.speed,
   frame = defaultPreset.params.frame,
+  image = 'https://shaders.paper.design/images/image-filters/0019.webp',
   contour = defaultPreset.params.contour,
   angle = defaultPreset.params.angle,
   noise = defaultPreset.params.noise,
@@ -76,7 +75,6 @@ export const Heatmap: React.FC<HeatmapProps> = memo(function HeatmapImpl({
 
   // Sizing props
   fit = defaultPreset.params.fit,
-  image = transparentPixel,
   offsetX = defaultPreset.params.offsetX,
   offsetY = defaultPreset.params.offsetY,
   originX = defaultPreset.params.originX,

--- a/packages/shaders-react/src/shaders/image-dithering.tsx
+++ b/packages/shaders-react/src/shaders/image-dithering.tsx
@@ -7,14 +7,14 @@ import {
   ShaderFitOptions,
   type ImageDitheringUniforms,
   type ImageDitheringParams,
-  type ShaderPreset,
   defaultObjectSizing,
   DitheringTypes,
+  type ImageShaderPreset,
 } from '@paper-design/shaders';
 
 export interface ImageDitheringProps extends ShaderComponentProps, ImageDitheringParams {}
 
-type ImageDitheringPreset = ShaderPreset<ImageDitheringParams>;
+type ImageDitheringPreset = ImageShaderPreset<ImageDitheringParams>;
 
 export const defaultPreset: ImageDitheringPreset = {
   name: 'Default',
@@ -27,7 +27,6 @@ export const defaultPreset: ImageDitheringPreset = {
     colorFront: '#94ffaf',
     colorBack: '#000c38',
     colorHighlight: '#eaff94',
-    image: 'https://shaders.paper.design/images/image-filters/0018.webp',
     type: '8x8',
     pxSize: 2,
     colorSteps: 2,
@@ -44,7 +43,6 @@ export const retroPreset: ImageDitheringPreset = {
     colorFront: '#eeeeee',
     colorBack: '#5452ff',
     colorHighlight: '#eeeeee',
-    image: 'https://shaders.paper.design/images/image-filters/0018.webp',
     type: '2x2',
     pxSize: 3,
     colorSteps: 1,
@@ -61,7 +59,6 @@ export const noisePreset: ImageDitheringPreset = {
     colorFront: '#a2997c',
     colorBack: '#000000',
     colorHighlight: '#ededed',
-    image: 'https://shaders.paper.design/images/image-filters/0018.webp',
     type: 'random',
     pxSize: 1,
     colorSteps: 1,
@@ -78,7 +75,6 @@ export const naturalPreset: ImageDitheringPreset = {
     colorFront: '#ffffff',
     colorBack: '#000000',
     colorHighlight: '#ffffff',
-    image: 'https://shaders.paper.design/images/image-filters/0018.webp',
     type: '8x8',
     pxSize: 2,
     colorSteps: 5,
@@ -95,7 +91,7 @@ export const ImageDithering: React.FC<ImageDitheringProps> = memo(function Image
   colorFront = defaultPreset.params.colorFront,
   colorBack = defaultPreset.params.colorBack,
   colorHighlight = defaultPreset.params.colorHighlight,
-  image = defaultPreset.params.image,
+  image = 'https://shaders.paper.design/images/image-filters/0018.webp',
   type = defaultPreset.params.type,
   pxSize = defaultPreset.params.pxSize,
   colorSteps = defaultPreset.params.colorSteps,

--- a/packages/shaders-react/src/shaders/paper-texture.tsx
+++ b/packages/shaders-react/src/shaders/paper-texture.tsx
@@ -7,14 +7,14 @@ import {
   getShaderNoiseTexture,
   paperTextureFragmentShader,
   ShaderFitOptions,
+  type ImageShaderPreset,
   type PaperTextureParams,
   type PaperTextureUniforms,
-  type ShaderPreset,
 } from '@paper-design/shaders';
 
 export interface PaperTextureProps extends ShaderComponentProps, PaperTextureParams {}
 
-type PaperTexturePreset = ShaderPreset<PaperTextureParams>;
+type PaperTexturePreset = ImageShaderPreset<PaperTextureParams>;
 
 export const defaultPreset: PaperTexturePreset = {
   name: 'Default',
@@ -26,7 +26,6 @@ export const defaultPreset: PaperTexturePreset = {
     frame: 0,
     colorFront: '#9fadbc',
     colorBack: '#ffffff',
-    image: 'https://shaders.paper.design/images/image-filters/0018.webp',
     contrast: 0.3,
     roughness: 0.4,
     fiber: 0.3,
@@ -51,7 +50,6 @@ export const abstractPreset: PaperTexturePreset = {
     scale: 0.6,
     colorFront: '#00eeff',
     colorBack: '#ff0a81',
-    image: 'https://shaders.paper.design/images/image-filters/0018.webp',
     contrast: 0.85,
     roughness: 0,
     fiber: 0.1,
@@ -76,7 +74,6 @@ export const cardboardPreset: PaperTexturePreset = {
     scale: 0.6,
     colorFront: '#c7b89e',
     colorBack: '#999180',
-    image: 'https://shaders.paper.design/images/image-filters/0018.webp',
     contrast: 0.4,
     roughness: 0,
     fiber: 0.35,
@@ -101,7 +98,6 @@ export const detailsPreset: PaperTexturePreset = {
     scale: 3,
     colorFront: '#00000000',
     colorBack: '#00000000',
-    image: 'https://shaders.paper.design/images/image-filters/0018.webp',
     contrast: 0,
     roughness: 1,
     fiber: 0.27,
@@ -129,7 +125,7 @@ export const PaperTexture: React.FC<PaperTextureProps> = memo(function PaperText
   frame = defaultPreset.params.frame,
   colorFront = defaultPreset.params.colorFront,
   colorBack = defaultPreset.params.colorBack,
-  image = defaultPreset.params.image,
+  image = 'https://shaders.paper.design/images/image-filters/0018.webp',
   contrast = defaultPreset.params.contrast,
   roughness = defaultPreset.params.roughness,
   fiber = defaultPreset.params.fiber,

--- a/packages/shaders-react/src/shaders/water.tsx
+++ b/packages/shaders-react/src/shaders/water.tsx
@@ -7,13 +7,13 @@ import {
   ShaderFitOptions,
   type WaterUniforms,
   type WaterParams,
-  type ShaderPreset,
   defaultObjectSizing,
+  type ImageShaderPreset,
 } from '@paper-design/shaders';
 
 export interface WaterProps extends ShaderComponentProps, WaterParams {}
 
-type WaterPreset = ShaderPreset<WaterParams>;
+type WaterPreset = ImageShaderPreset<WaterParams>;
 
 export const defaultPreset: WaterPreset = {
   name: 'Default',
@@ -24,7 +24,6 @@ export const defaultPreset: WaterPreset = {
     frame: 0,
     colorBack: '#909090',
     colorHighlight: '#ffffff',
-    image: 'https://shaders.paper.design/images/image-filters/0018.webp',
     highlights: 0.07,
     layering: 0.5,
     edges: 0.8,
@@ -44,7 +43,6 @@ export const abstractPreset: WaterPreset = {
     frame: 0,
     colorBack: '#909090',
     colorHighlight: '#ffffff',
-    image: 'https://shaders.paper.design/images/image-filters/0018.webp',
     highlights: 0,
     layering: 0,
     edges: 1,
@@ -64,7 +62,6 @@ export const streamingPreset: WaterPreset = {
     frame: 0,
     colorBack: '#909090',
     colorHighlight: '#ffffff',
-    image: 'https://shaders.paper.design/images/image-filters/0018.webp',
     highlights: 0,
     layering: 0,
     edges: 0,
@@ -84,7 +81,6 @@ export const slowMoPreset: WaterPreset = {
     frame: 0,
     colorBack: '#909090',
     colorHighlight: '#ffffff',
-    image: 'https://shaders.paper.design/images/image-filters/0018.webp',
     highlights: 0.4,
     layering: 0,
     edges: 0,
@@ -102,7 +98,7 @@ export const Water: React.FC<WaterProps> = memo(function WaterImpl({
   frame = defaultPreset.params.frame,
   colorBack = defaultPreset.params.colorBack,
   colorHighlight = defaultPreset.params.colorHighlight,
-  image = defaultPreset.params.image,
+  image = 'https://shaders.paper.design/images/image-filters/0018.webp',
   highlights = defaultPreset.params.highlights,
   layering = defaultPreset.params.layering,
   waves = defaultPreset.params.waves,

--- a/packages/shaders/src/index.ts
+++ b/packages/shaders/src/index.ts
@@ -1,6 +1,12 @@
 /** The core Shader Mount class. Pass it a parent element and a fragment shader to get started. */
 export { ShaderMount, isPaperShaderElement } from './shader-mount.js';
-export type { PaperShaderElement, ShaderMotionParams, ShaderMountUniforms, ShaderPreset } from './shader-mount.js';
+export type {
+  PaperShaderElement,
+  ShaderMotionParams,
+  ShaderMountUniforms,
+  ShaderPreset,
+  ImageShaderPreset,
+} from './shader-mount.js';
 
 /** Shader sizing options and uniforms */
 export {

--- a/packages/shaders/src/shader-mount.ts
+++ b/packages/shaders/src/shader-mount.ts
@@ -651,6 +651,13 @@ export type ShaderPreset<T> = {
 
 export type ImageShaderPreset<T> = {
   name: string;
+  /**
+   * Params for the shader excluding the image.
+   * Image is excluded as it isn't considered a preset,
+   * e.g. when switching between presets it shouldn't switch the image.
+   *
+   * While we exclude images from presets they should still be set with default values so the code-first usage of shaders remains great.
+   */
   params: Required<Omit<T, 'image'>>;
 };
 

--- a/packages/shaders/src/shader-mount.ts
+++ b/packages/shaders/src/shader-mount.ts
@@ -649,6 +649,11 @@ export type ShaderPreset<T> = {
   params: Required<T>;
 };
 
+export type ImageShaderPreset<T> = {
+  name: string;
+  params: Required<Omit<T, 'image'>>;
+};
+
 function isSafari() {
   const ua = navigator.userAgent.toLowerCase();
   return ua.includes('safari') && !ua.includes('chrome') && !ua.includes('android');

--- a/packages/shaders/src/shader-mount.ts
+++ b/packages/shaders/src/shader-mount.ts
@@ -656,7 +656,7 @@ export type ImageShaderPreset<T> = {
    * Image is excluded as it isn't considered a preset,
    * e.g. when switching between presets it shouldn't switch the image.
    *
-   * While we exclude images from presets they should still be set with default values so the code-first usage of shaders remains great.
+   * While we exclude images from presets they should still be set with a default prop value so the code-first usage of shaders remains great.
    */
   params: Required<Omit<T, 'image'>>;
 };


### PR DESCRIPTION
Because image shaders have `image` in their presets when selecting a preset inside paper it replaces the user uploaded image unexpectedly. This pull request removes `image` from the presets and moves it to default props fixing the bug while keeping the _out of the box_ behaviour we currently have when using shaders code first.