### PR TITLE
fix(heatmap): align u_imageAspectRatio precision with vertex shader f…

### DIFF
--- a/packages/shaders/src/shaders/heatmap.ts
+++ b/packages/shaders/src/shaders/heatmap.ts
@@ -16,7 +16,7 @@ out vec4 fragColor;
 
 uniform sampler2D u_image;
 uniform float u_time;
-uniform float u_imageAspectRatio;
+uniform mediump float u_imageAspectRatio;
 
 uniform vec4 u_colorBack;
 uniform vec4 u_colors[${heatmapMeta.maxColorCount}];


### PR DESCRIPTION
- Problem: Heatmap failed to link on Safari and Firefox with error:
  “Unable to initialize the shader program: Uniform u_imageAspectRatio is not linkable between attached shaders.”
- Cause: The fragment shader declared u_imageAspectRatio as float (implicitly highp after precision upgrade), while other shaders and drivers expect mediump, leading to a cross-stage precision mismatch during program linking on some browsers.
- Fix: Change declaration in heatmap fragment shader to mediump to match expectations and other image-based shaders.

Change
- packages/shaders/src/shaders/heatmap.ts
  - uniform float u_imageAspectRatio; → uniform mediump float u_imageAspectRatio;

Notes
- Verified against the shared vertex sizing logic using u_imageAspectRatio and compared with working shaders (water, paper-texture, image-dithering).
- After this change, heatmap initializes correctly on Safari and Firefox while remaining fine on Chrome.