### PR TITLE
Fix the webgl context attrs footgun, fix dispose

### DIFF
--- a/packages/shaders-react/src/shader-mount.tsx
+++ b/packages/shaders-react/src/shader-mount.tsx
@@ -136,6 +136,7 @@ export const ShaderMount: React.FC<ShaderMountProps> = forwardRef<PaperShaderEle
     const [isInitialized, setIsInitialized] = useState(false);
     const divRef = useRef<PaperShaderElement>(null);
     const shaderMountRef: React.RefObject<ShaderMountVanilla | null> = useRef<ShaderMountVanilla>(null);
+    const webGlContextAttributesRef = useRef(webGlContextAttributes);
 
     // Initialize the ShaderMountVanilla
     useEffect(() => {
@@ -147,7 +148,7 @@ export const ShaderMount: React.FC<ShaderMountProps> = forwardRef<PaperShaderEle
             divRef.current,
             fragmentShader,
             uniforms,
-            webGlContextAttributes,
+            webGlContextAttributesRef.current,
             speed,
             frame,
             minPixelRatio,
@@ -164,7 +165,7 @@ export const ShaderMount: React.FC<ShaderMountProps> = forwardRef<PaperShaderEle
         shaderMountRef.current?.dispose();
         shaderMountRef.current = null;
       };
-    }, [fragmentShader, webGlContextAttributes]);
+    }, [fragmentShader]);
 
     // Uniforms
     useEffect(() => {

--- a/packages/shaders/src/shader-mount.ts
+++ b/packages/shaders/src/shader-mount.ts
@@ -545,8 +545,10 @@ export class ShaderMount {
 
     this.uniformLocations = {};
 
-    // Remove the shader mount from the div wrapper element to avoid any GC issues
-    this.parentElement.paperShaderMount = undefined;
+    // Remove the shader from the div wrapper element
+    this.canvasElement.remove();
+    // Free up the reference to self to enable garbage collection
+    delete this.parentElement.paperShaderMount;
   };
 }
 


### PR DESCRIPTION
Fixes https://github.com/paper-design/shaders/issues/193

Test example to repro the bug on main:
```jsx
'use client';

import { FlutedGlass, Heatmap, ImageDithering, MeshGradient, PaperTexture, Water } from '@paper-design/shaders-react';
import { useState } from 'react';

export default function TestPage() {
  const [swirl, setSwirl] = useState(0);

  return (
    <div className="grid grid-cols-4 p-100 *:aspect-square">
      <button onClick={() => setSwirl(swirl + 0.1)}>Add swirl</button>
      <MeshGradient swirl={swirl} webGlContextAttributes={{}} />
    </div>
  );
}
```
(you can pop it into the test page)