### PR TITLE
Add Vue package for paper shaders

### DIFF
--- a/build.js
+++ b/build.js
@@ -49,3 +49,4 @@ async function build(packageDir) {
 
 build('packages/shaders');
 build('packages/shaders-react');
+build('packages/shaders-vue');

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "paper-shaders",
@@ -47,11 +48,11 @@
     },
     "packages/shaders": {
       "name": "@paper-design/shaders",
-      "version": "0.0.68",
+      "version": "0.0.72",
     },
     "packages/shaders-react": {
       "name": "@paper-design/shaders-react",
-      "version": "0.0.68",
+      "version": "0.0.72",
       "dependencies": {
         "@paper-design/shaders": "workspace:*",
       },
@@ -65,6 +66,19 @@
       "optionalPeers": [
         "@types/react",
       ],
+    },
+    "packages/shaders-vue": {
+      "name": "@paper-design/shaders-vue",
+      "version": "0.0.72",
+      "dependencies": {
+        "@paper-design/shaders": "0.0.72",
+      },
+      "devDependencies": {
+        "vue": "^3.4.0",
+      },
+      "peerDependencies": {
+        "vue": "^3.4.0",
+      },
     },
   },
   "patchedDependencies": {
@@ -281,7 +295,7 @@
 
     "@jridgewell/set-array": ["@jridgewell/set-array@1.2.1", "", {}, "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A=="],
 
-    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.0", "", {}, "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="],
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.25", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ=="],
 
@@ -318,6 +332,8 @@
     "@paper-design/shaders": ["@paper-design/shaders@workspace:packages/shaders"],
 
     "@paper-design/shaders-react": ["@paper-design/shaders-react@workspace:packages/shaders-react"],
+
+    "@paper-design/shaders-vue": ["@paper-design/shaders-vue@workspace:packages/shaders-vue"],
 
     "@radix-ui/popper": ["@radix-ui/popper@0.1.0", "", { "dependencies": { "@babel/runtime": "^7.13.10", "csstype": "^3.0.4" } }, "sha512-uzYeElL3w7SeNMuQpXiFlBhTT+JyaNMCwDfjKkrzugEcYrf5n52PHqncNdQPUtR42hJh8V9FsqyEDbDxkeNjJQ=="],
 
@@ -474,6 +490,26 @@
     "@use-gesture/react": ["@use-gesture/react@10.3.1", "", { "dependencies": { "@use-gesture/core": "10.3.1" }, "peerDependencies": { "react": ">= 16.8.0" } }, "sha512-Yy19y6O2GJq8f7CHf7L0nxL8bf4PZCPaVOCgJrusOeFHY1LvHgYXnmnXg6N5iwAnbgbZCDjo60SiM6IPJi9C5g=="],
 
     "@vercel/analytics": ["@vercel/analytics@1.5.0", "", { "peerDependencies": { "@remix-run/react": "^2", "@sveltejs/kit": "^1 || ^2", "next": ">= 13", "react": "^18 || ^19 || ^19.0.0-rc", "svelte": ">= 4", "vue": "^3", "vue-router": "^4" }, "optionalPeers": ["@remix-run/react", "@sveltejs/kit", "next", "react", "svelte", "vue", "vue-router"] }, "sha512-MYsBzfPki4gthY5HnYN7jgInhAZ7Ac1cYDoRWFomwGHWEX7odTEzbtg9kf/QSo7XEsEAqlQugA6gJ2WS2DEa3g=="],
+
+    "@vue/compiler-core": ["@vue/compiler-core@3.5.32", "", { "dependencies": { "@babel/parser": "^7.29.2", "@vue/shared": "3.5.32", "entities": "^7.0.1", "estree-walker": "^2.0.2", "source-map-js": "^1.2.1" } }, "sha512-4x74Tbtqnda8s/NSD6e1Dr5p1c8HdMU5RWSjMSUzb8RTcUQqevDCxVAitcLBKT+ie3o0Dl9crc/S/opJM7qBGQ=="],
+
+    "@vue/compiler-dom": ["@vue/compiler-dom@3.5.32", "", { "dependencies": { "@vue/compiler-core": "3.5.32", "@vue/shared": "3.5.32" } }, "sha512-ybHAu70NtiEI1fvAUz3oXZqkUYEe5J98GjMDpTGl5iHb0T15wQYLR4wE3h9xfuTNA+Cm2f4czfe8B4s+CCH57Q=="],
+
+    "@vue/compiler-sfc": ["@vue/compiler-sfc@3.5.32", "", { "dependencies": { "@babel/parser": "^7.29.2", "@vue/compiler-core": "3.5.32", "@vue/compiler-dom": "3.5.32", "@vue/compiler-ssr": "3.5.32", "@vue/shared": "3.5.32", "estree-walker": "^2.0.2", "magic-string": "^0.30.21", "postcss": "^8.5.8", "source-map-js": "^1.2.1" } }, "sha512-8UYUYo71cP/0YHMO814TRZlPuUUw3oifHuMR7Wp9SNoRSrxRQnhMLNlCeaODNn6kNTJsjFoQ/kqIj4qGvya4Xg=="],
+
+    "@vue/compiler-ssr": ["@vue/compiler-ssr@3.5.32", "", { "dependencies": { "@vue/compiler-dom": "3.5.32", "@vue/shared": "3.5.32" } }, "sha512-Gp4gTs22T3DgRotZ8aA/6m2jMR+GMztvBXUBEUOYOcST+giyGWJ4WvFd7QLHBkzTxkfOt8IELKNdpzITLbA2rw=="],
+
+    "@vue/devtools-api": ["@vue/devtools-api@6.6.4", "", {}, "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g=="],
+
+    "@vue/reactivity": ["@vue/reactivity@3.5.32", "", { "dependencies": { "@vue/shared": "3.5.32" } }, "sha512-/ORasxSGvZ6MN5gc+uE364SxFdJ0+WqVG0CENXaGW58TOCdrAW76WWaplDtECeS1qphvtBZtR+3/o1g1zL4xPQ=="],
+
+    "@vue/runtime-core": ["@vue/runtime-core@3.5.32", "", { "dependencies": { "@vue/reactivity": "3.5.32", "@vue/shared": "3.5.32" } }, "sha512-pDrXCejn4UpFDFmMd27AcJEbHaLemaE5o4pbb7sLk79SRIhc6/t34BQA7SGNgYtbMnvbF/HHOftYBgFJtUoJUQ=="],
+
+    "@vue/runtime-dom": ["@vue/runtime-dom@3.5.32", "", { "dependencies": { "@vue/reactivity": "3.5.32", "@vue/runtime-core": "3.5.32", "@vue/shared": "3.5.32", "csstype": "^3.2.3" } }, "sha512-1CDVv7tv/IV13V8Nip1k/aaObVbWqRlVCVezTwx3K07p7Vxossp5JU1dcPNhJk3w347gonIUT9jQOGutyJrSVQ=="],
+
+    "@vue/server-renderer": ["@vue/server-renderer@3.5.32", "", { "dependencies": { "@vue/compiler-ssr": "3.5.32", "@vue/shared": "3.5.32" }, "peerDependencies": { "vue": "3.5.32" } }, "sha512-IOjm2+JQwRFS7W28HNuJeXQle9KdZbODFY7hFGVtnnghF51ta20EWAZJHX+zLGtsHhaU6uC9BGPV52KVpYryMQ=="],
+
+    "@vue/shared": ["@vue/shared@3.5.32", "", {}, "sha512-ksNyrmRQzWJJ8n3cRDuSF7zNNontuJg1YHnmWRJd2AMu8Ij2bqwiiri2lH5rHtYPZjj4STkNcgcmiQqlOjiYGg=="],
 
     "acorn": ["acorn@8.14.1", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg=="],
 
@@ -635,6 +671,8 @@
 
     "enhanced-resolve": ["enhanced-resolve@5.18.3", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.2.0" } }, "sha512-d4lC8xfavMeBjzGr2vECC3fsGXziXZQyJxD868h2M/mBI3PwAuODxAkLkq5HYuvrPYcUtiLzsTo8U3PgX3Ocww=="],
 
+    "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
+
     "error-ex": ["error-ex@1.3.2", "", { "dependencies": { "is-arrayish": "^0.2.1" } }, "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g=="],
 
     "es-abstract": ["es-abstract@1.23.9", "", { "dependencies": { "array-buffer-byte-length": "^1.0.2", "arraybuffer.prototype.slice": "^1.0.4", "available-typed-arrays": "^1.0.7", "call-bind": "^1.0.8", "call-bound": "^1.0.3", "data-view-buffer": "^1.0.2", "data-view-byte-length": "^1.0.2", "data-view-byte-offset": "^1.0.1", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0", "es-set-tostringtag": "^2.1.0", "es-to-primitive": "^1.3.0", "function.prototype.name": "^1.1.8", "get-intrinsic": "^1.2.7", "get-proto": "^1.0.0", "get-symbol-description": "^1.1.0", "globalthis": "^1.0.4", "gopd": "^1.2.0", "has-property-descriptors": "^1.0.2", "has-proto": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "internal-slot": "^1.1.0", "is-array-buffer": "^3.0.5", "is-callable": "^1.2.7", "is-data-view": "^1.0.2", "is-regex": "^1.2.1", "is-shared-array-buffer": "^1.0.4", "is-string": "^1.1.1", "is-typed-array": "^1.1.15", "is-weakref": "^1.1.0", "math-intrinsics": "^1.1.0", "object-inspect": "^1.13.3", "object-keys": "^1.1.1", "object.assign": "^4.1.7", "own-keys": "^1.0.1", "regexp.prototype.flags": "^1.5.3", "safe-array-concat": "^1.1.3", "safe-push-apply": "^1.0.0", "safe-regex-test": "^1.1.0", "set-proto": "^1.0.0", "string.prototype.trim": "^1.2.10", "string.prototype.trimend": "^1.0.9", "string.prototype.trimstart": "^1.0.8", "typed-array-buffer": "^1.0.3", "typed-array-byte-length": "^1.0.3", "typed-array-byte-offset": "^1.0.4", "typed-array-length": "^1.0.7", "unbox-primitive": "^1.1.0", "which-typed-array": "^1.1.18" } }, "sha512-py07lI0wjxAC/DcfK1S6G7iANonniZwTISvdPzk9hzeH0IZIshbuuFxLIU96OyF89Yb9hiqWn8M/bY83KY5vzA=="],
@@ -690,6 +728,8 @@
     "esrecurse": ["esrecurse@4.3.0", "", { "dependencies": { "estraverse": "^5.2.0" } }, "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag=="],
 
     "estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
+
+    "estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
 
     "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
 
@@ -885,7 +925,7 @@
 
     "jackspeak": ["jackspeak@4.1.0", "", { "dependencies": { "@isaacs/cliui": "^8.0.2" } }, "sha512-9DDdhb5j6cpeitCbvLO7n7J4IxnbM6hoF6O1g4HQ5TfhvvKN8ywDM7668ZhMHRqVmxqhps/F6syWK2KcPxYlkw=="],
 
-    "jiti": ["jiti@1.21.7", "", { "bin": { "jiti": "bin/jiti.js" } }, "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A=="],
+    "jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
@@ -957,7 +997,7 @@
 
     "lru-cache": ["lru-cache@11.1.0", "", {}, "sha512-QIXZUBJUx+2zHUdQujWejBkcD9+cs94tLn0+YL8UrCh+D5sCXZ4c7LaEH48pNwRY3MLDgqUFyhlCyjJPf1WP0A=="],
 
-    "magic-string": ["magic-string@0.30.17", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0" } }, "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA=="],
+    "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
@@ -1285,6 +1325,10 @@
 
     "validate-npm-package-license": ["validate-npm-package-license@3.0.4", "", { "dependencies": { "spdx-correct": "^3.0.0", "spdx-expression-parse": "^3.0.0" } }, "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew=="],
 
+    "vue": ["vue@3.5.32", "", { "dependencies": { "@vue/compiler-dom": "3.5.32", "@vue/compiler-sfc": "3.5.32", "@vue/runtime-dom": "3.5.32", "@vue/server-renderer": "3.5.32", "@vue/shared": "3.5.32" }, "peerDependencies": { "typescript": "*" }, "optionalPeers": ["typescript"] }, "sha512-vM4z4Q9tTafVfMAK7IVzmxg34rSzTFMyIe0UUEijUCkn9+23lj0WRfA83dg7eQZIUlgOSGrkViIaCfqSAUXsMw=="],
+
+    "vue-router": ["vue-router@4.6.4", "", { "dependencies": { "@vue/devtools-api": "^6.6.4" }, "peerDependencies": { "vue": "^3.5.0" } }, "sha512-Hz9q5sa33Yhduglwz6g9skT8OBPii+4bFn88w6J+J4MfEo4KRRpmiNG/hHHkdbRFlLBOqxN8y8gf2Fb0MTUgVg=="],
+
     "wcwidth": ["wcwidth@1.0.1", "", { "dependencies": { "defaults": "^1.0.3" } }, "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg=="],
 
     "web-streams-polyfill": ["web-streams-polyfill@3.3.3", "", {}, "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="],
@@ -1332,6 +1376,10 @@
     "@eslint/plugin-kit/@eslint/core": ["@eslint/core@0.13.0", "", { "dependencies": { "@types/json-schema": "^7.0.15" } }, "sha512-yfkgDw1KR66rkT5A8ci4irzDysN7FRpq3ttJolR88OqQikAWqwA8j5VZyas+vjyBNFIJ7MfybJ9plMILI2UrCw=="],
 
     "@humanfs/node/@humanwhocodes/retry": ["@humanwhocodes/retry@0.3.1", "", {}, "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA=="],
+
+    "@jridgewell/gen-mapping/@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.0", "", {}, "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="],
+
+    "@jridgewell/trace-mapping/@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.0", "", {}, "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="],
 
     "@napi-rs/wasm-runtime/@emnapi/runtime": ["@emnapi/runtime@1.4.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-64WYIf4UYcdLnbKn/umDlNjQDSS8AgZrI/R9+x5ilkUVFxXcA1Ebl+gQLc/6mERA4407Xof0R7wEyEuj091CVw=="],
 
@@ -1429,6 +1477,8 @@
 
     "@tailwindcss/node/jiti": ["jiti@2.5.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-twQoecYPiVA5K/h6SxtORw/Bs3ar+mLUtoPSc7iMXzQzK8d7eJ/R09wmTwAjiamETn1cXYPGfNnu7DMoHgu12w=="],
 
+    "@tailwindcss/node/magic-string": ["magic-string@0.30.17", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0" } }, "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA=="],
+
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.4.5", "", { "dependencies": { "@emnapi/wasi-threads": "1.0.4", "tslib": "^2.4.0" }, "bundled": true }, "sha512-XsLw1dEOpkSX/WucdqUhPWP7hDxSvZiY+fsUC14h+FtQ2Ifni4znbBt8punRX+Uj2JG/uDb8nEHVKvrVlvdZ5Q=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.4.5", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-++LApOtY0pEEz1zrd9vy1/zXVaVJJ/EbAF3u0fXIzPJEDtnITsBGbbK0EkM72amhl/R5b+5xx0Y/QhcVOpuulg=="],
@@ -1446,6 +1496,14 @@
     "@ts-morph/common/mkdirp": ["mkdirp@2.1.6", "", { "bin": { "mkdirp": "dist/cjs/src/bin.js" } }, "sha512-+hEnITedc8LAtIP9u3HJDFIdcLV2vXP33sqLLIzkv1Db1zO/1OxbvYf0Y1OC/S/Qo5dxHXepofhmxL02PsKe+A=="],
 
     "@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
+
+    "@vue/compiler-core/@babel/parser": ["@babel/parser@7.29.2", "", { "dependencies": { "@babel/types": "^7.29.0" }, "bin": "./bin/babel-parser.js" }, "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA=="],
+
+    "@vue/compiler-sfc/@babel/parser": ["@babel/parser@7.29.2", "", { "dependencies": { "@babel/types": "^7.29.0" }, "bin": "./bin/babel-parser.js" }, "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA=="],
+
+    "@vue/compiler-sfc/postcss": ["postcss@8.5.9", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw=="],
+
+    "@vue/runtime-dom/csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
     "chalk/escape-string-regexp": ["escape-string-regexp@1.0.5", "", {}, "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="],
 
@@ -1490,6 +1548,8 @@
     "extend-shallow/is-extendable": ["is-extendable@0.1.1", "", {}, "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw=="],
 
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
+
+    "fdir/picomatch": ["picomatch@4.0.2", "", {}, "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg=="],
 
     "foreground-child/cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
@@ -1551,6 +1611,12 @@
 
     "@radix-ui/react-tooltip/react-dom/scheduler": ["scheduler@0.26.0", "", {}, "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA=="],
 
+    "@tailwindcss/node/magic-string/@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.0", "", {}, "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="],
+
+    "@vue/compiler-core/@babel/parser/@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
+
+    "@vue/compiler-sfc/@babel/parser/@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
+
     "eslint-plugin-import/minimatch/brace-expansion": ["brace-expansion@1.1.11", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA=="],
 
     "eslint-plugin-import/tsconfig-paths/json5": ["json5@1.0.2", "", { "dependencies": { "minimist": "^1.2.0" }, "bin": { "json5": "lib/cli.js" } }, "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA=="],
@@ -1596,6 +1662,14 @@
     "wrap-ansi-cjs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "wrap-ansi-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "@vue/compiler-core/@babel/parser/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
+
+    "@vue/compiler-core/@babel/parser/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+
+    "@vue/compiler-sfc/@babel/parser/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
+
+    "@vue/compiler-sfc/@babel/parser/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
 
     "eslint/chalk/ansi-styles/color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 

--- a/docs/src/app/(shaders)/spiral/page.tsx
+++ b/docs/src/app/(shaders)/spiral/page.tsx
@@ -27,7 +27,7 @@ const SpiralWithControls = () => {
       density: { value: defaults.density, min: 0, max: 1, order: 200 },
       distortion: { value: defaults.distortion, min: 0, max: 1, order: 201 },
       strokeWidth: { value: defaults.strokeWidth, min: 0, max: 1, order: 202 },
-      strokeTaper: { value: defaults.strokeTaper, min: 0, max: 1, order: 203 },
+      strokeTaper: { value: defaults.strokeTaper, min: -1, max: 1, order: 203 },
       strokeCap: { value: defaults.strokeCap, min: 0, max: 1, order: 204 },
       noise: { value: defaults.noise, min: 0, max: 1, order: 205 },
       noiseFrequency: { value: defaults.noiseFrequency, min: 0, max: 1, order: 206 },

--- a/docs/src/shader-defs/liquid-metal-def.ts
+++ b/docs/src/shader-defs/liquid-metal-def.ts
@@ -33,7 +33,7 @@ export const liquidMetalDef: ShaderDef = {
       type: 'enum',
       defaultValue: defaultParams.shape,
       description: 'The predefined shape used as an effect mask when no image is provided.',
-      options: ['none', 'circle', 'daisy', 'metaballs'],
+      options: ['none', 'circle', 'daisy', 'diamond', 'metaballs'],
     },
     {
       name: 'repetition',

--- a/docs/src/shader-defs/spiral-def.ts
+++ b/docs/src/shader-defs/spiral-def.ts
@@ -50,10 +50,10 @@ export const spiralDef: ShaderDef = {
     {
       name: 'strokeTaper',
       type: 'number',
-      min: 0,
+      min: -1,
       max: 1,
       defaultValue: defaultParams.strokeTaper,
-      description: 'how much the stroke is loosing width away from center (0 = full visibility)',
+      description: 'Stroke width taper along the spiral; positive = stroke fades out away from center, negative = stroke grows away from center (0 = uniform width)',
     },
     {
       name: 'strokeCap',

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "workspaces": [
     "docs",
     "packages/shaders",
-    "packages/shaders-react"
+    "packages/shaders-react",
+    "packages/shaders-vue"
   ],
   "scripts": {
     "build": "bun run build.js",

--- a/packages/shaders-react/LICENSE
+++ b/packages/shaders-react/LICENSE
@@ -1,21 +1,164 @@
-MIT License
+# PolyForm Shield License 1.0.0
 
-Copyright (c) 2024 Lost Coast Labs, Inc. (Paper Design)
+<https://polyformproject.org/licenses/shield/1.0.0>
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+## Acceptance
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+In order to get any license under these terms, you must agree
+to them as both strict obligations and conditions to all
+your licenses.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+## Copyright License
+
+The licensor grants you a copyright license for the
+software to do everything you might do with the software
+that would otherwise infringe the licensor's copyright
+in it for any permitted purpose.  However, you may
+only distribute the software according to [Distribution
+License](#distribution-license) and make changes or new works
+based on the software according to [Changes and New Works
+License](#changes-and-new-works-license).
+
+## Distribution License
+
+The licensor grants you an additional copyright license
+to distribute copies of the software.  Your license
+to distribute covers distributing the software with
+changes and new works permitted by [Changes and New Works
+License](#changes-and-new-works-license).
+
+## Notices
+
+You must ensure that anyone who gets a copy of any part of
+the software from you also gets a copy of these terms or the
+URL for them above, as well as copies of any plain-text lines
+beginning with `Required Notice:` that the licensor provided
+with the software.  For example:
+
+> Required Notice: Copyright Yoyodyne, Inc. (http://example.com)
+
+## Changes and New Works License
+
+The licensor grants you an additional copyright license to
+make changes and new works based on the software for any
+permitted purpose.
+
+## Patent License
+
+The licensor grants you a patent license for the software that
+covers patent claims the licensor can license, or becomes able
+to license, that you would infringe by using the software.
+
+## Noncompete
+
+Any purpose is a permitted purpose, except for providing any
+product that competes with the software or any product the
+licensor or any of its affiliates provides using the software.
+
+## Competition
+
+Goods and services compete even when they provide functionality
+through different kinds of interfaces or for different technical
+platforms.  Applications can compete with services, libraries
+with plugins, frameworks with development tools, and so on,
+even if they're written in different programming languages
+or for different computer architectures.  Goods and services
+compete even when provided free of charge.  If you market a
+product as a practical substitute for the software or another
+product, it definitely competes.
+
+## New Products
+
+If you are using the software to provide a product that does
+not compete, but the licensor or any of its affiliates brings
+your product into competition by providing a new version of
+the software or another product using the software, you may
+continue using versions of the software available under these
+terms beforehand to provide your competing product, but not
+any later versions.
+
+## Discontinued Products
+
+You may begin using the software to compete with a product
+or service that the licensor or any of its affiliates has
+stopped providing, unless the licensor includes a plain-text
+line beginning with `Licensor Line of Business:` with the
+software that mentions that line of business.  For example:
+
+> Licensor Line of Business: YoyodyneCMS Content Management
+System (http://example.com/cms)
+
+## Sales of Business
+
+If the licensor or any of its affiliates sells a line of
+business developing the software or using the software
+to provide a product, the buyer can also enforce
+[Noncompete](#noncompete) for that product.
+
+## Fair Use
+
+You may have "fair use" rights for the software under the
+law. These terms do not limit them.
+
+## No Other Rights
+
+These terms do not allow you to sublicense or transfer any of
+your licenses to anyone else, or prevent the licensor from
+granting licenses to anyone else.  These terms do not imply
+any other licenses.
+
+## Patent Defense
+
+If you make any written claim that the software infringes or
+contributes to infringement of any patent, your patent license
+for the software granted under these terms ends immediately. If
+your company makes such a claim, your patent license ends
+immediately for work on behalf of your company.
+
+## Violations
+
+The first time you are notified in writing that you have
+violated any of these terms, or done anything with the software
+not covered by your licenses, your licenses can nonetheless
+continue if you come into full compliance with these terms,
+and take practical steps to correct past violations, within
+32 days of receiving notice.  Otherwise, all your licenses
+end immediately.
+
+## No Liability
+
+***As far as the law allows, the software comes as is, without
+any warranty or condition, and the licensor will not be liable
+to you for any damages arising out of these terms or the use
+or nature of the software, under any kind of legal claim.***
+
+## Definitions
+
+The **licensor** is the individual or entity offering these
+terms, and the **software** is the software the licensor makes
+available under these terms.
+
+A **product** can be a good or service, or a combination
+of them.
+
+**You** refers to the individual or entity agreeing to these
+terms.
+
+**Your company** is any legal entity, sole proprietorship,
+or other kind of organization that you work for, plus all
+its affiliates.
+
+**Affiliates** means the other organizations than an
+organization has control over, is under the control of, or is
+under common control with.
+
+**Control** means ownership of substantially all the assets of
+an entity, or the power to direct its management and policies
+by vote, contract, or otherwise.  Control can be direct or
+indirect.
+
+**Your licenses** are all the licenses granted to you for the
+software under these terms.
+
+**Use** means anything you do with the software requiring one
+of your licenses.

--- a/packages/shaders-vue/README.md
+++ b/packages/shaders-vue/README.md
@@ -1,0 +1,46 @@
+# @paper-design/shaders-vue
+
+## Usage
+
+```vue
+<script setup lang="ts">
+import { MeshGradient, DotOrbit } from '@paper-design/shaders-vue';
+</script>
+
+<template>
+  <MeshGradient
+    :colors="['#5100ff', '#00ff80', '#ffcc00', '#ea00ff']"
+    :distortion="1"
+    :swirl="0.8"
+    :speed="0.2"
+    :style="{ width: '200px', height: '200px' }"
+  />
+
+  <DotOrbit
+    :colors="['#d2822d', '#0c3b7e', '#b31a57', '#37a066']"
+    color-back="#000000"
+    :scale="0.3"
+    :style="{ width: '200px', height: '200px' }"
+  />
+</template>
+```
+
+For Vue templates, bind booleans, numbers, arrays, and objects with `:prop="..."`.
+
+## Nuxt
+
+```vue
+<script setup lang="ts">
+import { MeshGradient } from '@paper-design/shaders-vue';
+</script>
+
+<template>
+  <MeshGradient class="hero-shader" :speed="0.6" />
+</template>
+```
+
+The components are SSR-safe and mount WebGL on the client after hydration.
+
+## Release notes
+
+[View changelog →](https://github.com/paper-design/shaders/blob/main/CHANGELOG.md)

--- a/packages/shaders-vue/package.json
+++ b/packages/shaders-vue/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@paper-design/shaders-vue",
+  "version": "0.0.72",
+  "license": "SEE LICENSE IN https://github.com/paper-design/shaders/blob/main/LICENSE",
+  "type": "module",
+  "sideEffects": false,
+  "publishConfig": {
+    "access": "public"
+  },
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "type-check": "tsc --project tsconfig.json"
+  },
+  "dependencies": {
+    "@paper-design/shaders": "0.0.72"
+  },
+  "devDependencies": {
+    "vue": "^3.4.0"
+  },
+  "peerDependencies": {
+    "vue": "^3.4.0"
+  }
+}

--- a/packages/shaders-vue/src/create-shader-component.ts
+++ b/packages/shaders-vue/src/create-shader-component.ts
@@ -1,0 +1,56 @@
+import { h, type FunctionalComponent } from 'vue';
+import { ShaderMount, type ShaderComponentProps, type ShaderMountInputUniforms } from './shader-mount.js';
+
+export interface ShaderComponentRenderResult extends ShaderComponentProps {
+  fragmentShader: string;
+  uniforms: ShaderMountInputUniforms;
+  speed?: number;
+  frame?: number;
+  mipmaps?: string[];
+}
+
+export type ShaderVueComponent<Props> = FunctionalComponent<Props> & {
+  new (): {
+    $props: Props;
+  };
+};
+
+const baseShaderComponentPropNames = [
+  'minPixelRatio',
+  'maxPixelCount',
+  'webGlContextAttributes',
+  'width',
+  'height',
+];
+
+export function shaderComponentPropNames(
+  defaultParams: Record<string, unknown>,
+  extraPropNames: string[] = []
+): string[] {
+  return [...new Set([...Object.keys(defaultParams), ...baseShaderComponentPropNames, ...extraPropNames])];
+}
+
+export function createShaderComponent<Props extends ShaderComponentProps>(
+  name: string,
+  propNames: string[],
+  build: (props: Props) => ShaderComponentRenderResult
+): ShaderVueComponent<Props> {
+  const component: FunctionalComponent<Props> = (rawProps, { attrs }) => {
+    const props = rawProps as Props;
+    const result = build(props);
+
+    return h(ShaderMount, {
+      ...attrs,
+      ...result,
+    });
+  };
+
+  component.props = propNames;
+  component.inheritAttrs = false;
+
+  Object.defineProperty(component, 'name', {
+    value: name,
+  });
+
+  return component as ShaderVueComponent<Props>;
+}

--- a/packages/shaders-vue/src/index.ts
+++ b/packages/shaders-vue/src/index.ts
@@ -1,0 +1,142 @@
+export { ShaderMount } from './shader-mount.js';
+export type {
+  ShaderMountProps,
+  ShaderComponentProps,
+  ShaderMountInputUniforms,
+  ShaderMountInputUniformValue,
+} from './shader-mount.js';
+
+export { createShaderComponent } from './create-shader-component.js';
+
+export { MeshGradient, meshGradientPresets } from './shaders-animated.js';
+export type { MeshGradientProps } from './shaders-animated.js';
+export type { MeshGradientUniforms, MeshGradientParams } from '@paper-design/shaders';
+
+export { SmokeRing, smokeRingPresets } from './shaders-animated.js';
+export type { SmokeRingProps } from './shaders-animated.js';
+export type { SmokeRingUniforms, SmokeRingParams } from '@paper-design/shaders';
+
+export { NeuroNoise, neuroNoisePresets } from './shaders-animated.js';
+export type { NeuroNoiseProps } from './shaders-animated.js';
+export type { NeuroNoiseUniforms, NeuroNoiseParams } from '@paper-design/shaders';
+
+export { DotOrbit, dotOrbitPresets } from './shaders-animated.js';
+export type { DotOrbitProps } from './shaders-animated.js';
+export type { DotOrbitUniforms, DotOrbitParams } from '@paper-design/shaders';
+
+export { DotGrid, dotGridPresets } from './shaders-static.js';
+export type { DotGridProps } from './shaders-static.js';
+export type { DotGridUniforms, DotGridParams } from '@paper-design/shaders';
+
+export { SimplexNoise, simplexNoisePresets } from './shaders-animated.js';
+export type { SimplexNoiseProps } from './shaders-animated.js';
+export type { SimplexNoiseUniforms, SimplexNoiseParams } from '@paper-design/shaders';
+
+export { Metaballs, metaballsPresets } from './shaders-animated.js';
+export type { MetaballsProps } from './shaders-animated.js';
+export type { MetaballsUniforms, MetaballsParams } from '@paper-design/shaders';
+
+export { Waves, wavesPresets } from './shaders-static.js';
+export type { WavesProps } from './shaders-static.js';
+export type { WavesUniforms, WavesParams } from '@paper-design/shaders';
+
+export { PerlinNoise, perlinNoisePresets } from './shaders-animated.js';
+export type { PerlinNoiseProps } from './shaders-animated.js';
+export type { PerlinNoiseUniforms, PerlinNoiseParams } from '@paper-design/shaders';
+
+export { Voronoi, voronoiPresets } from './shaders-animated.js';
+export type { VoronoiProps } from './shaders-animated.js';
+export type { VoronoiUniforms, VoronoiParams } from '@paper-design/shaders';
+
+export { Warp, warpPresets } from './shaders-animated.js';
+export type { WarpProps } from './shaders-animated.js';
+export type { WarpUniforms, WarpParams, WarpPattern } from '@paper-design/shaders';
+
+export { GodRays, godRaysPresets } from './shaders-animated.js';
+export type { GodRaysProps } from './shaders-animated.js';
+export type { GodRaysUniforms, GodRaysParams } from '@paper-design/shaders';
+
+export { Spiral, spiralPresets } from './shaders-animated.js';
+export type { SpiralProps } from './shaders-animated.js';
+export type { SpiralUniforms, SpiralParams } from '@paper-design/shaders';
+
+export { Swirl, swirlPresets } from './shaders-animated.js';
+export type { SwirlProps } from './shaders-animated.js';
+export type { SwirlUniforms, SwirlParams } from '@paper-design/shaders';
+
+export { Dithering, ditheringPresets } from './shaders-static.js';
+export type { DitheringProps } from './shaders-static.js';
+export type { DitheringUniforms, DitheringParams } from '@paper-design/shaders';
+
+export { GrainGradient, grainGradientPresets } from './shaders-animated.js';
+export type { GrainGradientProps } from './shaders-animated.js';
+export type { GrainGradientUniforms, GrainGradientParams } from '@paper-design/shaders';
+
+export { PulsingBorder, pulsingBorderPresets } from './shaders-animated.js';
+export type { PulsingBorderProps } from './shaders-animated.js';
+export type { PulsingBorderUniforms, PulsingBorderParams } from '@paper-design/shaders';
+
+export { ColorPanels, colorPanelsPresets } from './shaders-static.js';
+export type { ColorPanelsProps } from './shaders-static.js';
+export type { ColorPanelsUniforms, ColorPanelsParams } from '@paper-design/shaders';
+
+export { StaticMeshGradient, staticMeshGradientPresets } from './shaders-static.js';
+export type { StaticMeshGradientProps } from './shaders-static.js';
+export type { StaticMeshGradientUniforms, StaticMeshGradientParams } from '@paper-design/shaders';
+
+export { StaticRadialGradient, staticRadialGradientPresets } from './shaders-static.js';
+export type { StaticRadialGradientProps } from './shaders-static.js';
+export type { StaticRadialGradientUniforms, StaticRadialGradientParams } from '@paper-design/shaders';
+
+export { PaperTexture, paperTexturePresets } from './shaders-image.js';
+export type { PaperTextureProps } from './shaders-image.js';
+export type { PaperTextureUniforms, PaperTextureParams } from '@paper-design/shaders';
+
+export { FlutedGlass, flutedGlassPresets } from './shaders-image.js';
+export type { FlutedGlassProps } from './shaders-image.js';
+export type { FlutedGlassUniforms, FlutedGlassParams } from '@paper-design/shaders';
+
+export { Water, waterPresets } from './shaders-image.js';
+export type { WaterProps } from './shaders-image.js';
+export type { WaterUniforms, WaterParams } from '@paper-design/shaders';
+
+export { ImageDithering, imageDitheringPresets } from './shaders-image.js';
+export type { ImageDitheringProps } from './shaders-image.js';
+export type { ImageDitheringUniforms, ImageDitheringParams } from '@paper-design/shaders';
+
+export { Heatmap, heatmapPresets } from './shaders-image.js';
+export type { HeatmapProps } from './shaders-image.js';
+export type { HeatmapUniforms, HeatmapParams } from '@paper-design/shaders';
+
+export { LiquidMetal, liquidMetalPresets } from './shaders-image.js';
+export type { LiquidMetalProps } from './shaders-image.js';
+export type { LiquidMetalUniforms, LiquidMetalParams } from '@paper-design/shaders';
+
+export { HalftoneDots, halftoneDotsPresets } from './shaders-image.js';
+export type { HalftoneDotsProps } from './shaders-image.js';
+export type { HalftoneDotsUniforms, HalftoneDotsParams } from '@paper-design/shaders';
+
+export { HalftoneCmyk, halftoneCmykPresets } from './shaders-image.js';
+export type { HalftoneCmykProps } from './shaders-image.js';
+export type { HalftoneCmykUniforms, HalftoneCmykParams } from '@paper-design/shaders';
+
+export { isPaperShaderElement, getShaderColorFromString } from '@paper-design/shaders';
+export type { PaperShaderElement, ShaderFit, ShaderSizingParams, ShaderSizingUniforms } from '@paper-design/shaders';
+
+export {
+  colorPanelsMeta,
+  dotOrbitMeta,
+  godRaysMeta,
+  grainGradientMeta,
+  meshGradientMeta,
+  metaballsMeta,
+  pulsingBorderMeta,
+  simplexNoiseMeta,
+  smokeRingMeta,
+  swirlMeta,
+  voronoiMeta,
+  warpMeta,
+  heatmapMeta,
+  staticMeshGradientMeta,
+  staticRadialGradientMeta,
+} from '@paper-design/shaders';

--- a/packages/shaders-vue/src/set-min-image-size.ts
+++ b/packages/shaders-vue/src/set-min-image-size.ts
@@ -1,0 +1,15 @@
+/**
+ * Resize the image to at least 1024px on the shorter side.
+ * Makes sure that vector images are converted to bitmaps at an acceptable resolution.
+ */
+export function setMinImageSize(img: HTMLImageElement): void {
+  if (img.naturalWidth < 1024 && img.naturalHeight < 1024) {
+    if (img.naturalWidth < 1 || img.naturalHeight < 1) {
+      return;
+    }
+
+    const aspect = img.naturalWidth / img.naturalHeight;
+    img.width = Math.round(aspect > 1 ? 1024 * aspect : 1024);
+    img.height = Math.round(aspect > 1 ? 1024 : 1024 / aspect);
+  }
+}

--- a/packages/shaders-vue/src/shader-mount.ts
+++ b/packages/shaders-vue/src/shader-mount.ts
@@ -1,0 +1,306 @@
+import {
+  computed,
+  defineComponent,
+  h,
+  onBeforeUnmount,
+  onMounted,
+  shallowRef,
+  watch,
+  type HTMLAttributes,
+  type PropType,
+  type VNodeProps,
+} from 'vue';
+import {
+  ShaderMount as ShaderMountVanilla,
+  emptyPixel,
+  type PaperShaderElement,
+  type ShaderMotionParams,
+  type ShaderMountUniforms,
+} from '@paper-design/shaders';
+import { setMinImageSize } from './set-min-image-size.js';
+
+export type ShaderMountInputUniformValue =
+  | string
+  | boolean
+  | number
+  | number[]
+  | number[][]
+  | HTMLImageElement
+  | undefined;
+
+export interface ShaderMountInputUniforms {
+  [key: string]: ShaderMountInputUniformValue;
+}
+
+export interface ShaderComponentProps extends HTMLAttributes, VNodeProps {
+  minPixelRatio?: number;
+  maxPixelCount?: number;
+  webGlContextAttributes?: WebGLContextAttributes;
+  width?: string | number;
+  height?: string | number;
+}
+
+export interface ShaderMountProps extends ShaderComponentProps, ShaderMotionParams {
+  fragmentShader: string;
+  uniforms: ShaderMountInputUniforms;
+  mipmaps?: string[];
+}
+
+function normalizeDimension(value: string | number | undefined): string | number | undefined {
+  if (typeof value === 'string' && Number.isNaN(Number(value)) === false) {
+    return Number(value);
+  }
+
+  return value;
+}
+
+async function processUniforms(uniformsProp: ShaderMountInputUniforms): Promise<ShaderMountUniforms> {
+  const processedUniforms = {} as ShaderMountUniforms;
+  const imageLoadPromises: Promise<void>[] = [];
+
+  const isValidUrl = (url: string): boolean => {
+    try {
+      if (url.startsWith('/')) return true;
+      new URL(url);
+      return true;
+    } catch {
+      return false;
+    }
+  };
+
+  const isExternalUrl = (url: string): boolean => {
+    try {
+      if (url.startsWith('/')) return false;
+      const urlObject = new URL(url, window.location.origin);
+      return urlObject.origin !== window.location.origin;
+    } catch {
+      return false;
+    }
+  };
+
+  Object.entries(uniformsProp).forEach(([key, value]) => {
+    if (typeof value === 'string') {
+      const url = value || emptyPixel;
+
+      if (!isValidUrl(url)) {
+        console.warn(`Uniform "${key}" has invalid URL "${url}". Skipping image loading.`);
+        return;
+      }
+
+      const imagePromise = new Promise<void>((resolve, reject) => {
+        const img = new Image();
+        if (isExternalUrl(url)) {
+          img.crossOrigin = 'anonymous';
+        }
+        img.onload = () => {
+          setMinImageSize(img);
+          processedUniforms[key] = img;
+          resolve();
+        };
+        img.onerror = () => {
+          console.error(`Could not set uniforms. Failed to load image at ${url}`);
+          reject(new Error(`Failed to load image at ${url}`));
+        };
+        img.src = url;
+      });
+
+      imageLoadPromises.push(imagePromise);
+    } else if (value instanceof HTMLImageElement) {
+      setMinImageSize(value);
+      processedUniforms[key] = value;
+    } else if (value !== undefined) {
+      processedUniforms[key] = value;
+    }
+  });
+
+  await Promise.all(imageLoadPromises);
+  return processedUniforms;
+}
+
+export const ShaderMount = defineComponent({
+  name: 'ShaderMount',
+  inheritAttrs: false,
+  props: {
+    fragmentShader: {
+      type: String,
+      required: true,
+    },
+    uniforms: {
+      type: Object as PropType<ShaderMountInputUniforms>,
+      required: true,
+    },
+    speed: {
+      type: Number,
+      default: 0,
+    },
+    frame: {
+      type: Number,
+      default: 0,
+    },
+    mipmaps: {
+      type: Array as PropType<string[]>,
+      default: undefined,
+    },
+    minPixelRatio: {
+      type: Number,
+      default: undefined,
+    },
+    maxPixelCount: {
+      type: Number,
+      default: undefined,
+    },
+    webGlContextAttributes: {
+      type: Object as PropType<WebGLContextAttributes>,
+      default: undefined,
+    },
+    width: {
+      type: [String, Number] as PropType<string | number>,
+      default: undefined,
+    },
+    height: {
+      type: [String, Number] as PropType<string | number>,
+      default: undefined,
+    },
+  },
+  setup(props, { attrs, expose }) {
+    const elementRef = shallowRef<PaperShaderElement | null>(null);
+    const shaderMountRef = shallowRef<ShaderMountVanilla | null>(null);
+    const hasMounted = shallowRef(false);
+    const initialContextAttributes = props.webGlContextAttributes;
+    let initRequestId = 0;
+    let uniformRequestId = 0;
+
+    const initializeShader = async (): Promise<void> => {
+      if (!hasMounted.value || elementRef.value === null) return;
+
+      const requestId = ++initRequestId;
+      const uniforms = await processUniforms(props.uniforms);
+
+      if (requestId !== initRequestId || elementRef.value === null) {
+        return;
+      }
+
+      shaderMountRef.value?.dispose();
+      shaderMountRef.value = new ShaderMountVanilla(
+        elementRef.value,
+        props.fragmentShader,
+        uniforms,
+        initialContextAttributes,
+        props.speed,
+        props.frame,
+        props.minPixelRatio,
+        props.maxPixelCount,
+        props.mipmaps ?? []
+      );
+    };
+
+    const updateUniforms = async (): Promise<void> => {
+      if (!hasMounted.value || shaderMountRef.value === null) return;
+
+      const requestId = ++uniformRequestId;
+      const uniforms = await processUniforms(props.uniforms);
+
+      if (requestId !== uniformRequestId) {
+        return;
+      }
+
+      shaderMountRef.value?.setUniforms(uniforms);
+    };
+
+    onMounted(() => {
+      hasMounted.value = true;
+      void initializeShader();
+    });
+
+    onBeforeUnmount(() => {
+      hasMounted.value = false;
+      initRequestId += 1;
+      uniformRequestId += 1;
+      shaderMountRef.value?.dispose();
+      shaderMountRef.value = null;
+    });
+
+    watch(
+      () => props.fragmentShader,
+      () => {
+        if (hasMounted.value) {
+          void initializeShader();
+        }
+      }
+    );
+
+    watch(
+      () => props.mipmaps,
+      () => {
+        if (hasMounted.value) {
+          void initializeShader();
+        }
+      },
+      { deep: true }
+    );
+
+    watch(
+      () => props.uniforms,
+      () => {
+        if (hasMounted.value) {
+          void updateUniforms();
+        }
+      },
+      { deep: true }
+    );
+
+    watch(
+      () => props.speed,
+      (speed) => {
+        shaderMountRef.value?.setSpeed(speed);
+      }
+    );
+
+    watch(
+      () => props.frame,
+      (frame) => {
+        shaderMountRef.value?.setFrame(frame);
+      }
+    );
+
+    watch(
+      () => props.maxPixelCount,
+      (maxPixelCount) => {
+        shaderMountRef.value?.setMaxPixelCount(maxPixelCount);
+      }
+    );
+
+    watch(
+      () => props.minPixelRatio,
+      (minPixelRatio) => {
+        shaderMountRef.value?.setMinPixelRatio(minPixelRatio);
+      }
+    );
+
+    const mergedStyle = computed(() => {
+      if (props.width === undefined && props.height === undefined) {
+        return attrs.style;
+      }
+
+      return [
+        {
+          width: normalizeDimension(props.width),
+          height: normalizeDimension(props.height),
+        },
+        attrs.style,
+      ];
+    });
+
+    expose({
+      el: elementRef,
+      shaderMount: shaderMountRef,
+    });
+
+    return () =>
+      h('div', {
+        ...attrs,
+        ref: elementRef,
+        style: mergedStyle.value,
+      });
+  },
+});

--- a/packages/shaders-vue/src/shaders-animated.ts
+++ b/packages/shaders-vue/src/shaders-animated.ts
@@ -1,0 +1,1999 @@
+import {
+  GrainGradientShapes,
+  PulsingBorderAspectRatios,
+  ShaderFitOptions,
+  WarpPatterns,
+  defaultObjectSizing,
+  defaultPatternSizing,
+  dotOrbitFragmentShader,
+  getShaderColorFromString,
+  getShaderNoiseTexture,
+  godRaysFragmentShader,
+  grainGradientFragmentShader,
+  meshGradientFragmentShader,
+  metaballsFragmentShader,
+  neuroNoiseFragmentShader,
+  perlinNoiseFragmentShader,
+  pulsingBorderFragmentShader,
+  simplexNoiseFragmentShader,
+  smokeRingFragmentShader,
+  spiralFragmentShader,
+  swirlFragmentShader,
+  voronoiFragmentShader,
+  warpFragmentShader,
+  type DotOrbitParams,
+  type DotOrbitUniforms,
+  type GodRaysParams,
+  type GodRaysUniforms,
+  type GrainGradientParams,
+  type GrainGradientUniforms,
+  type MeshGradientParams,
+  type MeshGradientUniforms,
+  type MetaballsParams,
+  type MetaballsUniforms,
+  type NeuroNoiseParams,
+  type NeuroNoiseUniforms,
+  type PerlinNoiseParams,
+  type PerlinNoiseUniforms,
+  type PulsingBorderParams,
+  type PulsingBorderUniforms,
+  type ShaderPreset,
+  type SimplexNoiseParams,
+  type SimplexNoiseUniforms,
+  type SmokeRingParams,
+  type SmokeRingUniforms,
+  type SpiralParams,
+  type SpiralUniforms,
+  type SwirlParams,
+  type SwirlUniforms,
+  type VoronoiParams,
+  type VoronoiUniforms,
+  type WarpParams,
+  type WarpUniforms,
+} from '@paper-design/shaders';
+import { createShaderComponent, shaderComponentPropNames } from './create-shader-component.js';
+import type { ShaderComponentProps } from './shader-mount.js';
+
+export interface MeshGradientProps extends ShaderComponentProps, MeshGradientParams {}
+
+const meshGradientDefaultPreset: ShaderPreset<MeshGradientParams> = {
+  name: 'Default',
+  params: {
+    ...defaultObjectSizing,
+    speed: 1,
+    frame: 0,
+    colors: ['#e0eaff', '#241d9a', '#f75092', '#9f50d3'],
+    distortion: 0.8,
+    swirl: 0.1,
+    grainMixer: 0,
+    grainOverlay: 0,
+  },
+};
+
+const meshGradientPurplePreset: ShaderPreset<MeshGradientParams> = {
+  name: 'Purple',
+  params: {
+    ...defaultObjectSizing,
+    speed: 0.6,
+    frame: 0,
+    colors: ['#aaa7d7', '#3c2b8e'],
+    distortion: 1,
+    swirl: 1,
+    grainMixer: 0,
+    grainOverlay: 0,
+  },
+};
+
+const meshGradientBeachPreset: ShaderPreset<MeshGradientParams> = {
+  name: 'Beach',
+  params: {
+    ...defaultObjectSizing,
+    speed: 0.1,
+    frame: 0,
+    colors: ['#bcecf6', '#00aaff', '#00f7ff', '#ffd447'],
+    distortion: 0.8,
+    swirl: 0.35,
+    grainMixer: 0,
+    grainOverlay: 0,
+  },
+};
+
+const meshGradientInkPreset: ShaderPreset<MeshGradientParams> = {
+  name: 'Ink',
+  params: {
+    ...defaultObjectSizing,
+    speed: 1,
+    frame: 0,
+    colors: ['#ffffff', '#000000'],
+    distortion: 1,
+    swirl: 0.2,
+    rotation: 90,
+    grainMixer: 0,
+    grainOverlay: 0,
+  },
+};
+
+export const meshGradientPresets = [
+  meshGradientDefaultPreset,
+  meshGradientInkPreset,
+  meshGradientPurplePreset,
+  meshGradientBeachPreset,
+] satisfies ShaderPreset<MeshGradientParams>[];
+
+export const MeshGradient = createShaderComponent<MeshGradientProps>(
+  'MeshGradient',
+  shaderComponentPropNames(meshGradientDefaultPreset.params),
+  ({
+    speed = meshGradientDefaultPreset.params.speed,
+    frame = meshGradientDefaultPreset.params.frame,
+    colors = meshGradientDefaultPreset.params.colors,
+    distortion = meshGradientDefaultPreset.params.distortion,
+    swirl = meshGradientDefaultPreset.params.swirl,
+    grainMixer = meshGradientDefaultPreset.params.grainMixer,
+    grainOverlay = meshGradientDefaultPreset.params.grainOverlay,
+    fit = meshGradientDefaultPreset.params.fit,
+    rotation = meshGradientDefaultPreset.params.rotation,
+    scale = meshGradientDefaultPreset.params.scale,
+    originX = meshGradientDefaultPreset.params.originX,
+    originY = meshGradientDefaultPreset.params.originY,
+    offsetX = meshGradientDefaultPreset.params.offsetX,
+    offsetY = meshGradientDefaultPreset.params.offsetY,
+    worldWidth = meshGradientDefaultPreset.params.worldWidth,
+    worldHeight = meshGradientDefaultPreset.params.worldHeight,
+    ...props
+  }: MeshGradientProps) => {
+    const uniforms = {
+      u_colors: colors.map(getShaderColorFromString),
+      u_colorsCount: colors.length,
+      u_distortion: distortion,
+      u_swirl: swirl,
+      u_grainMixer: grainMixer,
+      u_grainOverlay: grainOverlay,
+      u_fit: ShaderFitOptions[fit],
+      u_rotation: rotation,
+      u_scale: scale,
+      u_offsetX: offsetX,
+      u_offsetY: offsetY,
+      u_originX: originX,
+      u_originY: originY,
+      u_worldWidth: worldWidth,
+      u_worldHeight: worldHeight,
+    } satisfies MeshGradientUniforms;
+
+    return {
+      ...props,
+      speed,
+      frame,
+      fragmentShader: meshGradientFragmentShader,
+      uniforms,
+    };
+  }
+);
+
+export interface SmokeRingProps extends ShaderComponentProps, SmokeRingParams {}
+
+const smokeRingDefaultPreset: ShaderPreset<SmokeRingParams> = {
+  name: 'Default',
+  params: {
+    ...defaultObjectSizing,
+    speed: 0.5,
+    frame: 0,
+    colorBack: '#000000',
+    colors: ['#ffffff'],
+    noiseScale: 3,
+    noiseIterations: 8,
+    radius: 0.25,
+    thickness: 0.65,
+    innerShape: 0.7,
+    scale: 0.8,
+  },
+};
+
+const smokeRingSolarPreset: ShaderPreset<SmokeRingParams> = {
+  name: 'Solar',
+  params: {
+    ...defaultObjectSizing,
+    speed: 1,
+    frame: 0,
+    colorBack: '#000000',
+    colors: ['#ffffff', '#ffca0a', '#fc6203', '#fc620366'],
+    noiseScale: 2,
+    noiseIterations: 3,
+    radius: 0.4,
+    thickness: 0.8,
+    innerShape: 4,
+    scale: 2,
+    offsetY: 1,
+  },
+};
+
+const smokeRingLinePreset: ShaderPreset<SmokeRingParams> = {
+  name: 'Line',
+  params: {
+    ...defaultObjectSizing,
+    frame: 0,
+    colorBack: '#000000',
+    colors: ['#4540a4', '#1fe8ff'],
+    noiseScale: 1.1,
+    noiseIterations: 2,
+    radius: 0.38,
+    thickness: 0.01,
+    innerShape: 0.88,
+    speed: 4,
+  },
+};
+
+const smokeRingCloudPreset: ShaderPreset<SmokeRingParams> = {
+  name: 'Cloud',
+  params: {
+    ...defaultObjectSizing,
+    frame: 0,
+    colorBack: '#81ADEC',
+    colors: ['#ffffff'],
+    noiseScale: 3,
+    noiseIterations: 10,
+    radius: 0.5,
+    thickness: 0.65,
+    innerShape: 0.85,
+    speed: 0.5,
+    scale: 2.5,
+  },
+};
+
+export const smokeRingPresets = [
+  smokeRingDefaultPreset,
+  smokeRingLinePreset,
+  smokeRingSolarPreset,
+  smokeRingCloudPreset,
+] satisfies ShaderPreset<SmokeRingParams>[];
+
+export const SmokeRing = createShaderComponent<SmokeRingProps>(
+  'SmokeRing',
+  shaderComponentPropNames(smokeRingDefaultPreset.params),
+  ({
+    speed = smokeRingDefaultPreset.params.speed,
+    frame = smokeRingDefaultPreset.params.frame,
+    colorBack = smokeRingDefaultPreset.params.colorBack,
+    colors = smokeRingDefaultPreset.params.colors,
+    noiseScale = smokeRingDefaultPreset.params.noiseScale,
+    thickness = smokeRingDefaultPreset.params.thickness,
+    radius = smokeRingDefaultPreset.params.radius,
+    innerShape = smokeRingDefaultPreset.params.innerShape,
+    noiseIterations = smokeRingDefaultPreset.params.noiseIterations,
+    fit = smokeRingDefaultPreset.params.fit,
+    scale = smokeRingDefaultPreset.params.scale,
+    rotation = smokeRingDefaultPreset.params.rotation,
+    originX = smokeRingDefaultPreset.params.originX,
+    originY = smokeRingDefaultPreset.params.originY,
+    offsetX = smokeRingDefaultPreset.params.offsetX,
+    offsetY = smokeRingDefaultPreset.params.offsetY,
+    worldWidth = smokeRingDefaultPreset.params.worldWidth,
+    worldHeight = smokeRingDefaultPreset.params.worldHeight,
+    ...props
+  }: SmokeRingProps) => {
+    const uniforms = {
+      u_colorBack: getShaderColorFromString(colorBack),
+      u_colors: colors.map(getShaderColorFromString),
+      u_colorsCount: colors.length,
+      u_noiseScale: noiseScale,
+      u_thickness: thickness,
+      u_radius: radius,
+      u_innerShape: innerShape,
+      u_noiseIterations: noiseIterations,
+      u_noiseTexture: getShaderNoiseTexture(),
+      u_fit: ShaderFitOptions[fit],
+      u_scale: scale,
+      u_rotation: rotation,
+      u_offsetX: offsetX,
+      u_offsetY: offsetY,
+      u_originX: originX,
+      u_originY: originY,
+      u_worldWidth: worldWidth,
+      u_worldHeight: worldHeight,
+    } satisfies SmokeRingUniforms;
+
+    return {
+      ...props,
+      speed,
+      frame,
+      fragmentShader: smokeRingFragmentShader,
+      uniforms,
+    };
+  }
+);
+
+export interface NeuroNoiseProps extends ShaderComponentProps, NeuroNoiseParams {}
+
+const neuroNoiseDefaultPreset: ShaderPreset<NeuroNoiseParams> = {
+  name: 'Default',
+  params: {
+    ...defaultPatternSizing,
+    speed: 1,
+    frame: 0,
+    colorFront: '#ffffff',
+    colorMid: '#47a6ff',
+    colorBack: '#000000',
+    brightness: 0.05,
+    contrast: 0.3,
+  },
+};
+
+const neuroNoiseSensationPreset: ShaderPreset<NeuroNoiseParams> = {
+  name: 'Sensation',
+  params: {
+    ...defaultPatternSizing,
+    speed: 1,
+    frame: 0,
+    colorFront: '#00c8ff',
+    colorMid: '#fbff00',
+    colorBack: '#8b42ff',
+    brightness: 0.19,
+    contrast: 0.12,
+    scale: 3,
+  },
+};
+
+const neuroNoiseBloodstreamPreset: ShaderPreset<NeuroNoiseParams> = {
+  name: 'Bloodstream',
+  params: {
+    ...defaultPatternSizing,
+    speed: 1,
+    frame: 0,
+    colorFront: '#ff0000',
+    colorMid: '#ff0000',
+    colorBack: '#ffffff',
+    brightness: 0.24,
+    contrast: 0.17,
+    scale: 0.7,
+  },
+};
+
+const neuroNoiseGhostPreset: ShaderPreset<NeuroNoiseParams> = {
+  name: 'Ghost',
+  params: {
+    ...defaultPatternSizing,
+    speed: 1,
+    frame: 0,
+    colorFront: '#ffffff',
+    colorMid: '#000000',
+    colorBack: '#ffffff',
+    brightness: 0,
+    contrast: 1,
+    scale: 0.55,
+  },
+};
+
+export const neuroNoisePresets = [
+  neuroNoiseDefaultPreset,
+  neuroNoiseSensationPreset,
+  neuroNoiseBloodstreamPreset,
+  neuroNoiseGhostPreset,
+] satisfies ShaderPreset<NeuroNoiseParams>[];
+
+export const NeuroNoise = createShaderComponent<NeuroNoiseProps>(
+  'NeuroNoise',
+  shaderComponentPropNames(neuroNoiseDefaultPreset.params),
+  ({
+    speed = neuroNoiseDefaultPreset.params.speed,
+    frame = neuroNoiseDefaultPreset.params.frame,
+    colorFront = neuroNoiseDefaultPreset.params.colorFront,
+    colorMid = neuroNoiseDefaultPreset.params.colorMid,
+    colorBack = neuroNoiseDefaultPreset.params.colorBack,
+    brightness = neuroNoiseDefaultPreset.params.brightness,
+    contrast = neuroNoiseDefaultPreset.params.contrast,
+    fit = neuroNoiseDefaultPreset.params.fit,
+    scale = neuroNoiseDefaultPreset.params.scale,
+    rotation = neuroNoiseDefaultPreset.params.rotation,
+    originX = neuroNoiseDefaultPreset.params.originX,
+    originY = neuroNoiseDefaultPreset.params.originY,
+    offsetX = neuroNoiseDefaultPreset.params.offsetX,
+    offsetY = neuroNoiseDefaultPreset.params.offsetY,
+    worldWidth = neuroNoiseDefaultPreset.params.worldWidth,
+    worldHeight = neuroNoiseDefaultPreset.params.worldHeight,
+    ...props
+  }: NeuroNoiseProps) => {
+    const uniforms = {
+      u_colorFront: getShaderColorFromString(colorFront),
+      u_colorMid: getShaderColorFromString(colorMid),
+      u_colorBack: getShaderColorFromString(colorBack),
+      u_brightness: brightness,
+      u_contrast: contrast,
+      u_fit: ShaderFitOptions[fit],
+      u_scale: scale,
+      u_rotation: rotation,
+      u_offsetX: offsetX,
+      u_offsetY: offsetY,
+      u_originX: originX,
+      u_originY: originY,
+      u_worldWidth: worldWidth,
+      u_worldHeight: worldHeight,
+    } satisfies NeuroNoiseUniforms;
+
+    return {
+      ...props,
+      speed,
+      frame,
+      fragmentShader: neuroNoiseFragmentShader,
+      uniforms,
+    };
+  }
+);
+
+export interface DotOrbitProps extends ShaderComponentProps, DotOrbitParams {}
+
+const dotOrbitDefaultPreset: ShaderPreset<DotOrbitParams> = {
+  name: 'Default',
+  params: {
+    ...defaultPatternSizing,
+    speed: 1.5,
+    frame: 0,
+    colorBack: '#000000',
+    colors: ['#ffc96b', '#ff6200', '#ff2f00', '#421100', '#1a0000'],
+    size: 1,
+    sizeRange: 0,
+    spreading: 1,
+    stepsPerColor: 4,
+  },
+};
+
+const dotOrbitShinePreset: ShaderPreset<DotOrbitParams> = {
+  name: 'Shine',
+  params: {
+    ...defaultPatternSizing,
+    speed: 0.1,
+    frame: 0,
+    colors: ['#ffffff', '#006aff', '#fff675'],
+    colorBack: '#000000',
+    stepsPerColor: 4,
+    size: 0.3,
+    sizeRange: 0.2,
+    spreading: 1,
+    scale: 0.4,
+  },
+};
+
+const dotOrbitBubblesPreset: ShaderPreset<DotOrbitParams> = {
+  name: 'Bubbles',
+  params: {
+    ...defaultPatternSizing,
+    speed: 0.4,
+    frame: 0,
+    colors: ['#D0D2D5'],
+    colorBack: '#989CA4',
+    stepsPerColor: 2,
+    size: 0.9,
+    sizeRange: 0.7,
+    spreading: 1,
+    scale: 1.64,
+  },
+};
+
+const dotOrbitHallucinatoryPreset: ShaderPreset<DotOrbitParams> = {
+  name: 'Hallucinatory',
+  params: {
+    ...defaultPatternSizing,
+    speed: 5,
+    frame: 0,
+    colors: ['#000000'],
+    colorBack: '#ffe500',
+    stepsPerColor: 2,
+    size: 0.65,
+    sizeRange: 0,
+    spreading: 0.3,
+    scale: 0.5,
+  },
+};
+
+export const dotOrbitPresets = [
+  dotOrbitDefaultPreset,
+  dotOrbitBubblesPreset,
+  dotOrbitShinePreset,
+  dotOrbitHallucinatoryPreset,
+] satisfies ShaderPreset<DotOrbitParams>[];
+
+export const DotOrbit = createShaderComponent<DotOrbitProps>(
+  'DotOrbit',
+  shaderComponentPropNames(dotOrbitDefaultPreset.params),
+  ({
+    speed = dotOrbitDefaultPreset.params.speed,
+    frame = dotOrbitDefaultPreset.params.frame,
+    colorBack = dotOrbitDefaultPreset.params.colorBack,
+    colors = dotOrbitDefaultPreset.params.colors,
+    size = dotOrbitDefaultPreset.params.size,
+    sizeRange = dotOrbitDefaultPreset.params.sizeRange,
+    spreading = dotOrbitDefaultPreset.params.spreading,
+    stepsPerColor = dotOrbitDefaultPreset.params.stepsPerColor,
+    fit = dotOrbitDefaultPreset.params.fit,
+    scale = dotOrbitDefaultPreset.params.scale,
+    rotation = dotOrbitDefaultPreset.params.rotation,
+    originX = dotOrbitDefaultPreset.params.originX,
+    originY = dotOrbitDefaultPreset.params.originY,
+    offsetX = dotOrbitDefaultPreset.params.offsetX,
+    offsetY = dotOrbitDefaultPreset.params.offsetY,
+    worldWidth = dotOrbitDefaultPreset.params.worldWidth,
+    worldHeight = dotOrbitDefaultPreset.params.worldHeight,
+    ...props
+  }: DotOrbitProps) => {
+    const uniforms = {
+      u_colorBack: getShaderColorFromString(colorBack),
+      u_colors: colors.map(getShaderColorFromString),
+      u_colorsCount: colors.length,
+      u_size: size,
+      u_sizeRange: sizeRange,
+      u_spreading: spreading,
+      u_stepsPerColor: stepsPerColor,
+      u_noiseTexture: getShaderNoiseTexture(),
+      u_fit: ShaderFitOptions[fit],
+      u_scale: scale,
+      u_rotation: rotation,
+      u_offsetX: offsetX,
+      u_offsetY: offsetY,
+      u_originX: originX,
+      u_originY: originY,
+      u_worldWidth: worldWidth,
+      u_worldHeight: worldHeight,
+    } satisfies DotOrbitUniforms;
+
+    return {
+      ...props,
+      speed,
+      frame,
+      fragmentShader: dotOrbitFragmentShader,
+      uniforms,
+    };
+  }
+);
+
+export interface SimplexNoiseProps extends ShaderComponentProps, SimplexNoiseParams {}
+
+const simplexNoiseDefaultPreset: ShaderPreset<SimplexNoiseParams> = {
+  name: 'Default',
+  params: {
+    ...defaultPatternSizing,
+    scale: 0.6,
+    speed: 0.5,
+    frame: 0,
+    colors: ['#4449CF', '#FFD1E0', '#F94446', '#FFD36B', '#FFFFFF'],
+    stepsPerColor: 2,
+    softness: 0,
+  },
+};
+
+const simplexNoiseBubblegumPreset: ShaderPreset<SimplexNoiseParams> = {
+  name: 'Bubblegum',
+  params: {
+    ...defaultPatternSizing,
+    speed: 2,
+    frame: 0,
+    colors: ['#ffffff', '#ff9e9e', '#5f57ff', '#00f7ff'],
+    stepsPerColor: 1,
+    softness: 1,
+    scale: 1.6,
+  },
+};
+
+const simplexNoiseSpotsPreset: ShaderPreset<SimplexNoiseParams> = {
+  name: 'Spots',
+  params: {
+    ...defaultPatternSizing,
+    speed: 0.6,
+    frame: 0,
+    colors: ['#ff7b00', '#f9ffeb', '#320d82'],
+    stepsPerColor: 1,
+    softness: 0,
+    scale: 1,
+  },
+};
+
+const simplexNoiseFirstContactPreset: ShaderPreset<SimplexNoiseParams> = {
+  name: 'First contact',
+  params: {
+    ...defaultPatternSizing,
+    speed: 2,
+    frame: 0,
+    colors: ['#e8cce6', '#120d22', '#442c44', '#e6baba', '#fff5f5'],
+    stepsPerColor: 2,
+    softness: 0,
+    scale: 0.2,
+  },
+};
+
+export const simplexNoisePresets = [
+  simplexNoiseDefaultPreset,
+  simplexNoiseSpotsPreset,
+  simplexNoiseFirstContactPreset,
+  simplexNoiseBubblegumPreset,
+] satisfies ShaderPreset<SimplexNoiseParams>[];
+
+export const SimplexNoise = createShaderComponent<SimplexNoiseProps>(
+  'SimplexNoise',
+  shaderComponentPropNames(simplexNoiseDefaultPreset.params),
+  ({
+    speed = simplexNoiseDefaultPreset.params.speed,
+    frame = simplexNoiseDefaultPreset.params.frame,
+    colors = simplexNoiseDefaultPreset.params.colors,
+    stepsPerColor = simplexNoiseDefaultPreset.params.stepsPerColor,
+    softness = simplexNoiseDefaultPreset.params.softness,
+    fit = simplexNoiseDefaultPreset.params.fit,
+    scale = simplexNoiseDefaultPreset.params.scale,
+    rotation = simplexNoiseDefaultPreset.params.rotation,
+    originX = simplexNoiseDefaultPreset.params.originX,
+    originY = simplexNoiseDefaultPreset.params.originY,
+    offsetX = simplexNoiseDefaultPreset.params.offsetX,
+    offsetY = simplexNoiseDefaultPreset.params.offsetY,
+    worldWidth = simplexNoiseDefaultPreset.params.worldWidth,
+    worldHeight = simplexNoiseDefaultPreset.params.worldHeight,
+    ...props
+  }: SimplexNoiseProps) => {
+    const uniforms = {
+      u_colors: colors.map(getShaderColorFromString),
+      u_colorsCount: colors.length,
+      u_stepsPerColor: stepsPerColor,
+      u_softness: softness,
+      u_fit: ShaderFitOptions[fit],
+      u_scale: scale,
+      u_rotation: rotation,
+      u_offsetX: offsetX,
+      u_offsetY: offsetY,
+      u_originX: originX,
+      u_originY: originY,
+      u_worldWidth: worldWidth,
+      u_worldHeight: worldHeight,
+    } satisfies SimplexNoiseUniforms;
+
+    return {
+      ...props,
+      speed,
+      frame,
+      fragmentShader: simplexNoiseFragmentShader,
+      uniforms,
+    };
+  }
+);
+
+export interface MetaballsProps extends ShaderComponentProps, MetaballsParams {}
+
+const metaballsDefaultPreset: ShaderPreset<MetaballsParams> = {
+  name: 'Default',
+  params: {
+    ...defaultObjectSizing,
+    scale: 1,
+    speed: 1,
+    frame: 0,
+    colorBack: '#000000',
+    colors: ['#6e33cc', '#ff5500', '#ffc105', '#ffc800', '#f585ff'],
+    count: 10,
+    size: 0.83,
+  },
+};
+
+const metaballsInkDropsPreset: ShaderPreset<MetaballsParams> = {
+  name: 'Ink Drops',
+  params: {
+    ...defaultObjectSizing,
+    scale: 1,
+    speed: 2,
+    frame: 0,
+    colorBack: '#ffffff00',
+    colors: ['#000000'],
+    count: 18,
+    size: 0.1,
+  },
+};
+
+const metaballsBackgroundPreset: ShaderPreset<MetaballsParams> = {
+  name: 'Background',
+  params: {
+    ...defaultObjectSizing,
+    speed: 0.5,
+    frame: 0,
+    colors: ['#ae00ff', '#00ff95', '#ffc105'],
+    colorBack: '#2a273f',
+    count: 13,
+    size: 0.81,
+    scale: 4,
+    rotation: 0,
+    offsetX: -0.3,
+  },
+};
+
+const metaballsSolarPreset: ShaderPreset<MetaballsParams> = {
+  name: 'Solar',
+  params: {
+    ...defaultObjectSizing,
+    speed: 1,
+    frame: 0,
+    colors: ['#ffc800', '#ff5500', '#ffc105'],
+    colorBack: '#102f84',
+    count: 7,
+    size: 0.75,
+    scale: 1,
+  },
+};
+
+export const metaballsPresets = [
+  metaballsDefaultPreset,
+  metaballsInkDropsPreset,
+  metaballsSolarPreset,
+  metaballsBackgroundPreset,
+] satisfies ShaderPreset<MetaballsParams>[];
+
+export const Metaballs = createShaderComponent<MetaballsProps>(
+  'Metaballs',
+  shaderComponentPropNames(metaballsDefaultPreset.params),
+  ({
+    speed = metaballsDefaultPreset.params.speed,
+    frame = metaballsDefaultPreset.params.frame,
+    colorBack = metaballsDefaultPreset.params.colorBack,
+    colors = metaballsDefaultPreset.params.colors,
+    size = metaballsDefaultPreset.params.size,
+    count = metaballsDefaultPreset.params.count,
+    fit = metaballsDefaultPreset.params.fit,
+    rotation = metaballsDefaultPreset.params.rotation,
+    scale = metaballsDefaultPreset.params.scale,
+    originX = metaballsDefaultPreset.params.originX,
+    originY = metaballsDefaultPreset.params.originY,
+    offsetX = metaballsDefaultPreset.params.offsetX,
+    offsetY = metaballsDefaultPreset.params.offsetY,
+    worldWidth = metaballsDefaultPreset.params.worldWidth,
+    worldHeight = metaballsDefaultPreset.params.worldHeight,
+    ...props
+  }: MetaballsProps) => {
+    const uniforms = {
+      u_colorBack: getShaderColorFromString(colorBack),
+      u_colors: colors.map(getShaderColorFromString),
+      u_colorsCount: colors.length,
+      u_size: size,
+      u_count: count,
+      u_noiseTexture: getShaderNoiseTexture(),
+      u_fit: ShaderFitOptions[fit],
+      u_rotation: rotation,
+      u_scale: scale,
+      u_offsetX: offsetX,
+      u_offsetY: offsetY,
+      u_originX: originX,
+      u_originY: originY,
+      u_worldWidth: worldWidth,
+      u_worldHeight: worldHeight,
+    } satisfies MetaballsUniforms;
+
+    return {
+      ...props,
+      speed,
+      frame,
+      fragmentShader: metaballsFragmentShader,
+      uniforms,
+    };
+  }
+);
+
+export interface PerlinNoiseProps extends ShaderComponentProps, PerlinNoiseParams {}
+
+const perlinNoiseDefaultPreset: ShaderPreset<PerlinNoiseParams> = {
+  name: 'Default',
+  params: {
+    ...defaultPatternSizing,
+    speed: 0.5,
+    frame: 0,
+    colorBack: '#632ad5',
+    colorFront: '#fccff7',
+    proportion: 0.35,
+    softness: 0.1,
+    octaveCount: 1,
+    persistence: 1,
+    lacunarity: 1.5,
+  },
+};
+
+const perlinNoiseNintendoWaterPreset: ShaderPreset<PerlinNoiseParams> = {
+  name: 'Nintendo Water',
+  params: {
+    ...defaultPatternSizing,
+    scale: 1 / 0.2,
+    speed: 0.4,
+    frame: 0,
+    colorBack: '#2d69d4',
+    colorFront: '#d1eefc',
+    proportion: 0.42,
+    softness: 0,
+    octaveCount: 2,
+    persistence: 0.55,
+    lacunarity: 1.8,
+  },
+};
+
+const perlinNoiseMossPreset: ShaderPreset<PerlinNoiseParams> = {
+  name: 'Moss',
+  params: {
+    ...defaultPatternSizing,
+    scale: 1 / 0.15,
+    speed: 0.02,
+    frame: 0,
+    colorBack: '#05ff4a',
+    colorFront: '#262626',
+    proportion: 0.65,
+    softness: 0.35,
+    octaveCount: 6,
+    persistence: 1,
+    lacunarity: 2.55,
+  },
+};
+
+const perlinNoiseWormsPreset: ShaderPreset<PerlinNoiseParams> = {
+  name: 'Worms',
+  params: {
+    ...defaultPatternSizing,
+    scale: 0.9,
+    speed: 0,
+    frame: 0,
+    colorBack: '#ffffff00',
+    colorFront: '#595959',
+    proportion: 0.5,
+    softness: 0,
+    octaveCount: 1,
+    persistence: 1,
+    lacunarity: 1.5,
+  },
+};
+
+export const perlinNoisePresets = [
+  perlinNoiseDefaultPreset,
+  perlinNoiseNintendoWaterPreset,
+  perlinNoiseMossPreset,
+  perlinNoiseWormsPreset,
+] satisfies ShaderPreset<PerlinNoiseParams>[];
+
+export const PerlinNoise = createShaderComponent<PerlinNoiseProps>(
+  'PerlinNoise',
+  shaderComponentPropNames(perlinNoiseDefaultPreset.params),
+  ({
+    speed = perlinNoiseDefaultPreset.params.speed,
+    frame = perlinNoiseDefaultPreset.params.frame,
+    colorFront = perlinNoiseDefaultPreset.params.colorFront,
+    colorBack = perlinNoiseDefaultPreset.params.colorBack,
+    proportion = perlinNoiseDefaultPreset.params.proportion,
+    softness = perlinNoiseDefaultPreset.params.softness,
+    octaveCount = perlinNoiseDefaultPreset.params.octaveCount,
+    persistence = perlinNoiseDefaultPreset.params.persistence,
+    lacunarity,
+    fit = perlinNoiseDefaultPreset.params.fit,
+    worldWidth = perlinNoiseDefaultPreset.params.worldWidth,
+    worldHeight = perlinNoiseDefaultPreset.params.worldHeight,
+    scale = perlinNoiseDefaultPreset.params.scale,
+    rotation = perlinNoiseDefaultPreset.params.rotation,
+    originX = perlinNoiseDefaultPreset.params.originX,
+    originY = perlinNoiseDefaultPreset.params.originY,
+    offsetX = perlinNoiseDefaultPreset.params.offsetX,
+    offsetY = perlinNoiseDefaultPreset.params.offsetY,
+    ...props
+  }: PerlinNoiseProps) => {
+    const uniforms = {
+      u_colorBack: getShaderColorFromString(colorBack),
+      u_colorFront: getShaderColorFromString(colorFront),
+      u_proportion: proportion,
+      u_softness: softness ?? perlinNoiseDefaultPreset.params.softness,
+      u_octaveCount: octaveCount ?? perlinNoiseDefaultPreset.params.octaveCount,
+      u_persistence: persistence ?? perlinNoiseDefaultPreset.params.persistence,
+      u_lacunarity: lacunarity ?? perlinNoiseDefaultPreset.params.lacunarity,
+      u_fit: ShaderFitOptions[fit],
+      u_scale: scale,
+      u_rotation: rotation,
+      u_offsetX: offsetX,
+      u_offsetY: offsetY,
+      u_originX: originX,
+      u_originY: originY,
+      u_worldWidth: worldWidth,
+      u_worldHeight: worldHeight,
+    } satisfies PerlinNoiseUniforms;
+
+    return {
+      ...props,
+      speed,
+      frame,
+      fragmentShader: perlinNoiseFragmentShader,
+      uniforms,
+    };
+  }
+);
+
+export interface VoronoiProps extends ShaderComponentProps, VoronoiParams {}
+
+const voronoiDefaultPreset: ShaderPreset<VoronoiParams> = {
+  name: 'Default',
+  params: {
+    ...defaultPatternSizing,
+    speed: 0.5,
+    frame: 0,
+    colors: ['#ff8247', '#ffe53d'],
+    stepsPerColor: 3,
+    colorGlow: '#ffffff',
+    colorGap: '#2e0000',
+    distortion: 0.4,
+    gap: 0.04,
+    glow: 0,
+    scale: 0.5,
+  },
+};
+
+const voronoiCellsPreset: ShaderPreset<VoronoiParams> = {
+  name: 'Cells',
+  params: {
+    ...defaultPatternSizing,
+    scale: 0.5,
+    speed: 0.5,
+    frame: 0,
+    colors: ['#ffffff'],
+    stepsPerColor: 1,
+    colorGlow: '#ffffff',
+    colorGap: '#000000',
+    distortion: 0.5,
+    gap: 0.03,
+    glow: 0.8,
+  },
+};
+
+const voronoiBubblesPreset: ShaderPreset<VoronoiParams> = {
+  name: 'Bubbles',
+  params: {
+    ...defaultPatternSizing,
+    scale: 0.75,
+    speed: 0.5,
+    frame: 0,
+    colors: ['#83c9fb'],
+    stepsPerColor: 1,
+    colorGlow: '#ffffff',
+    colorGap: '#ffffff',
+    distortion: 0.4,
+    gap: 0,
+    glow: 1,
+  },
+};
+
+const voronoiLightsPreset: ShaderPreset<VoronoiParams> = {
+  name: 'Lights',
+  params: {
+    ...defaultPatternSizing,
+    scale: 3.3,
+    speed: 0.5,
+    frame: 0,
+    colors: ['#fffffffc', '#bbff00', '#00ffff'],
+    colorGlow: '#ff00d0',
+    colorGap: '#ff00d0',
+    stepsPerColor: 2,
+    distortion: 0.38,
+    gap: 0,
+    glow: 1,
+  },
+};
+
+export const voronoiPresets = [
+  voronoiDefaultPreset,
+  voronoiLightsPreset,
+  voronoiCellsPreset,
+  voronoiBubblesPreset,
+] satisfies ShaderPreset<VoronoiParams>[];
+
+export const Voronoi = createShaderComponent<VoronoiProps>(
+  'Voronoi',
+  shaderComponentPropNames(voronoiDefaultPreset.params),
+  ({
+    speed = voronoiDefaultPreset.params.speed,
+    frame = voronoiDefaultPreset.params.frame,
+    colors = voronoiDefaultPreset.params.colors,
+    stepsPerColor = voronoiDefaultPreset.params.stepsPerColor,
+    colorGlow = voronoiDefaultPreset.params.colorGlow,
+    colorGap = voronoiDefaultPreset.params.colorGap,
+    distortion = voronoiDefaultPreset.params.distortion,
+    gap = voronoiDefaultPreset.params.gap,
+    glow = voronoiDefaultPreset.params.glow,
+    fit = voronoiDefaultPreset.params.fit,
+    scale = voronoiDefaultPreset.params.scale,
+    rotation = voronoiDefaultPreset.params.rotation,
+    originX = voronoiDefaultPreset.params.originX,
+    originY = voronoiDefaultPreset.params.originY,
+    offsetX = voronoiDefaultPreset.params.offsetX,
+    offsetY = voronoiDefaultPreset.params.offsetY,
+    worldWidth = voronoiDefaultPreset.params.worldWidth,
+    worldHeight = voronoiDefaultPreset.params.worldHeight,
+    ...props
+  }: VoronoiProps) => {
+    const uniforms = {
+      u_colors: colors.map(getShaderColorFromString),
+      u_colorsCount: colors.length,
+      u_stepsPerColor: stepsPerColor,
+      u_colorGlow: getShaderColorFromString(colorGlow),
+      u_colorGap: getShaderColorFromString(colorGap),
+      u_distortion: distortion,
+      u_gap: gap,
+      u_glow: glow,
+      u_noiseTexture: getShaderNoiseTexture(),
+      u_fit: ShaderFitOptions[fit],
+      u_scale: scale,
+      u_rotation: rotation,
+      u_offsetX: offsetX,
+      u_offsetY: offsetY,
+      u_originX: originX,
+      u_originY: originY,
+      u_worldWidth: worldWidth,
+      u_worldHeight: worldHeight,
+    } satisfies VoronoiUniforms;
+
+    return {
+      ...props,
+      speed,
+      frame,
+      fragmentShader: voronoiFragmentShader,
+      uniforms,
+    };
+  }
+);
+
+export interface WarpProps extends ShaderComponentProps, WarpParams {}
+
+const warpDefaultPreset: ShaderPreset<WarpParams> = {
+  name: 'Default',
+  params: {
+    ...defaultPatternSizing,
+    rotation: 0,
+    speed: 1,
+    frame: 0,
+    colors: ['#121212', '#9470ff', '#121212', '#8838ff'],
+    proportion: 0.45,
+    softness: 1,
+    distortion: 0.25,
+    swirl: 0.8,
+    swirlIterations: 10,
+    shapeScale: 0.1,
+    shape: 'checks',
+  },
+};
+
+const warpCauldronPreset: ShaderPreset<WarpParams> = {
+  name: 'Cauldron Pot',
+  params: {
+    ...defaultPatternSizing,
+    scale: 0.9,
+    rotation: 160,
+    speed: 10,
+    frame: 0,
+    colors: ['#a7e58b', '#324472', '#0a180d'],
+    proportion: 0.64,
+    softness: 1.5,
+    distortion: 0.2,
+    swirl: 0.86,
+    swirlIterations: 7,
+    shapeScale: 0.6,
+    shape: 'edge',
+  },
+};
+
+const warpInkPreset: ShaderPreset<WarpParams> = {
+  name: 'Live Ink',
+  params: {
+    ...defaultPatternSizing,
+    scale: 1.2,
+    rotation: 44,
+    offsetY: -0.3,
+    speed: 2.5,
+    frame: 0,
+    colors: ['#111314', '#9faeab', '#f3fee7', '#f3fee7'],
+    proportion: 0.05,
+    softness: 0,
+    distortion: 0.25,
+    swirl: 0.8,
+    swirlIterations: 10,
+    shapeScale: 0.28,
+    shape: 'checks',
+  },
+};
+
+const warpKelpPreset: ShaderPreset<WarpParams> = {
+  name: 'Kelp',
+  params: {
+    ...defaultPatternSizing,
+    scale: 0.8,
+    rotation: 50,
+    speed: 20,
+    frame: 0,
+    colors: ['#dbff8f', '#404f3e', '#091316'],
+    proportion: 0.67,
+    softness: 0,
+    distortion: 0,
+    swirl: 0.2,
+    swirlIterations: 3,
+    shapeScale: 1,
+    shape: 'stripes',
+  },
+};
+
+const warpNectarPreset: ShaderPreset<WarpParams> = {
+  name: 'Nectar',
+  params: {
+    ...defaultPatternSizing,
+    scale: 2,
+    offsetY: 0.6,
+    rotation: 0,
+    speed: 4.2,
+    frame: 0,
+    colors: ['#151310', '#d3a86b', '#f0edea'],
+    proportion: 0.24,
+    softness: 1,
+    distortion: 0.21,
+    swirl: 0.57,
+    swirlIterations: 10,
+    shapeScale: 0.75,
+    shape: 'edge',
+  },
+};
+
+const warpPassionPreset: ShaderPreset<WarpParams> = {
+  name: 'Passion',
+  params: {
+    ...defaultPatternSizing,
+    scale: 2.5,
+    rotation: 1.35,
+    speed: 3,
+    frame: 0,
+    colors: ['#3b1515', '#954751', '#ffc085'],
+    proportion: 0.5,
+    softness: 1,
+    distortion: 0.09,
+    swirl: 0.9,
+    swirlIterations: 6,
+    shapeScale: 0.25,
+    shape: 'checks',
+  },
+};
+
+export const warpPresets = [
+  warpDefaultPreset,
+  warpCauldronPreset,
+  warpInkPreset,
+  warpKelpPreset,
+  warpNectarPreset,
+  warpPassionPreset,
+] satisfies ShaderPreset<WarpParams>[];
+
+export const Warp = createShaderComponent<WarpProps>(
+  'Warp',
+  shaderComponentPropNames(warpDefaultPreset.params),
+  ({
+    speed = warpDefaultPreset.params.speed,
+    frame = warpDefaultPreset.params.frame,
+    colors = warpDefaultPreset.params.colors,
+    proportion = warpDefaultPreset.params.proportion,
+    softness = warpDefaultPreset.params.softness,
+    distortion = warpDefaultPreset.params.distortion,
+    swirl = warpDefaultPreset.params.swirl,
+    swirlIterations = warpDefaultPreset.params.swirlIterations,
+    shapeScale = warpDefaultPreset.params.shapeScale,
+    shape = warpDefaultPreset.params.shape,
+    fit = warpDefaultPreset.params.fit,
+    scale = warpDefaultPreset.params.scale,
+    rotation = warpDefaultPreset.params.rotation,
+    originX = warpDefaultPreset.params.originX,
+    originY = warpDefaultPreset.params.originY,
+    offsetX = warpDefaultPreset.params.offsetX,
+    offsetY = warpDefaultPreset.params.offsetY,
+    worldWidth = warpDefaultPreset.params.worldWidth,
+    worldHeight = warpDefaultPreset.params.worldHeight,
+    ...props
+  }: WarpProps) => {
+    const uniforms = {
+      u_colors: colors.map(getShaderColorFromString),
+      u_colorsCount: colors.length,
+      u_proportion: proportion,
+      u_softness: softness,
+      u_distortion: distortion,
+      u_swirl: swirl,
+      u_swirlIterations: swirlIterations,
+      u_shapeScale: shapeScale,
+      u_shape: WarpPatterns[shape],
+      u_noiseTexture: getShaderNoiseTexture(),
+      u_scale: scale,
+      u_rotation: rotation,
+      u_fit: ShaderFitOptions[fit],
+      u_offsetX: offsetX,
+      u_offsetY: offsetY,
+      u_originX: originX,
+      u_originY: originY,
+      u_worldWidth: worldWidth,
+      u_worldHeight: worldHeight,
+    } satisfies WarpUniforms;
+
+    return {
+      ...props,
+      speed,
+      frame,
+      fragmentShader: warpFragmentShader,
+      uniforms,
+    };
+  }
+);
+
+export interface GodRaysProps extends ShaderComponentProps, GodRaysParams {}
+
+const godRaysDefaultPreset: ShaderPreset<GodRaysParams> = {
+  name: 'Default',
+  params: {
+    ...defaultObjectSizing,
+    offsetX: 0,
+    offsetY: -0.55,
+    colorBack: '#000000',
+    colorBloom: '#0000ff',
+    colors: ['#a600ff6e', '#6200fff0', '#ffffff', '#33fff5'],
+    density: 0.3,
+    spotty: 0.3,
+    midIntensity: 0.4,
+    midSize: 0.2,
+    intensity: 0.8,
+    bloom: 0.4,
+    speed: 0.75,
+    frame: 0,
+  },
+};
+
+const godRaysWarpPreset: ShaderPreset<GodRaysParams> = {
+  name: 'Warp',
+  params: {
+    ...defaultObjectSizing,
+    colorBack: '#000000',
+    colorBloom: '#222288',
+    colors: ['#ff47d4', '#ff8c00', '#ffffff'],
+    density: 0.45,
+    spotty: 0.15,
+    midIntensity: 0.4,
+    midSize: 0.33,
+    intensity: 0.79,
+    bloom: 0.4,
+    speed: 2,
+    frame: 0,
+  },
+};
+
+const godRaysLinearPreset: ShaderPreset<GodRaysParams> = {
+  name: 'Linear',
+  params: {
+    ...defaultObjectSizing,
+    offsetX: 0.2,
+    offsetY: -0.8,
+    colorBack: '#000000',
+    colorBloom: '#eeeeee',
+    colors: ['#ffffff1f', '#ffffff3d', '#ffffff29'],
+    density: 0.41,
+    spotty: 0.25,
+    midSize: 0.1,
+    midIntensity: 0.75,
+    intensity: 0.79,
+    bloom: 1,
+    speed: 0.5,
+    frame: 0,
+  },
+};
+
+const godRaysEtherPreset: ShaderPreset<GodRaysParams> = {
+  name: 'Ether',
+  params: {
+    ...defaultObjectSizing,
+    offsetX: -0.6,
+    colorBack: '#090f1d',
+    colorBloom: '#ffffff',
+    colors: ['#148effa6', '#c4dffebe', '#232a47'],
+    density: 0.03,
+    spotty: 0.77,
+    midSize: 0.1,
+    midIntensity: 0.6,
+    intensity: 0.6,
+    bloom: 0.6,
+    speed: 1,
+    frame: 0,
+  },
+};
+
+export const godRaysPresets = [
+  godRaysDefaultPreset,
+  godRaysWarpPreset,
+  godRaysLinearPreset,
+  godRaysEtherPreset,
+] satisfies ShaderPreset<GodRaysParams>[];
+
+export const GodRays = createShaderComponent<GodRaysProps>(
+  'GodRays',
+  shaderComponentPropNames(godRaysDefaultPreset.params),
+  ({
+    speed = godRaysDefaultPreset.params.speed,
+    frame = godRaysDefaultPreset.params.frame,
+    colorBloom = godRaysDefaultPreset.params.colorBloom,
+    colorBack = godRaysDefaultPreset.params.colorBack,
+    colors = godRaysDefaultPreset.params.colors,
+    density = godRaysDefaultPreset.params.density,
+    spotty = godRaysDefaultPreset.params.spotty,
+    midIntensity = godRaysDefaultPreset.params.midIntensity,
+    midSize = godRaysDefaultPreset.params.midSize,
+    intensity = godRaysDefaultPreset.params.intensity,
+    bloom = godRaysDefaultPreset.params.bloom,
+    fit = godRaysDefaultPreset.params.fit,
+    scale = godRaysDefaultPreset.params.scale,
+    rotation = godRaysDefaultPreset.params.rotation,
+    originX = godRaysDefaultPreset.params.originX,
+    originY = godRaysDefaultPreset.params.originY,
+    offsetX = godRaysDefaultPreset.params.offsetX,
+    offsetY = godRaysDefaultPreset.params.offsetY,
+    worldWidth = godRaysDefaultPreset.params.worldWidth,
+    worldHeight = godRaysDefaultPreset.params.worldHeight,
+    ...props
+  }: GodRaysProps) => {
+    const uniforms = {
+      u_colorBloom: getShaderColorFromString(colorBloom),
+      u_colorBack: getShaderColorFromString(colorBack),
+      u_colors: colors.map(getShaderColorFromString),
+      u_colorsCount: colors.length,
+      u_density: density,
+      u_spotty: spotty,
+      u_midIntensity: midIntensity,
+      u_midSize: midSize,
+      u_intensity: intensity,
+      u_bloom: bloom,
+      u_noiseTexture: getShaderNoiseTexture(),
+      u_fit: ShaderFitOptions[fit],
+      u_scale: scale,
+      u_rotation: rotation,
+      u_offsetX: offsetX,
+      u_offsetY: offsetY,
+      u_originX: originX,
+      u_originY: originY,
+      u_worldWidth: worldWidth,
+      u_worldHeight: worldHeight,
+    } satisfies GodRaysUniforms;
+
+    return {
+      ...props,
+      speed,
+      frame,
+      fragmentShader: godRaysFragmentShader,
+      uniforms,
+    };
+  }
+);
+
+export interface SpiralProps extends ShaderComponentProps, SpiralParams {}
+
+const spiralDefaultPreset: ShaderPreset<SpiralParams> = {
+  name: 'Default',
+  params: {
+    ...defaultPatternSizing,
+    scale: 1,
+    colorBack: '#001429',
+    colorFront: '#79D1FF',
+    density: 1,
+    distortion: 0,
+    strokeWidth: 0.5,
+    strokeTaper: 0,
+    strokeCap: 0,
+    noise: 0,
+    noiseFrequency: 0,
+    softness: 0,
+    speed: 1,
+    frame: 0,
+  },
+};
+
+const spiralDropletPreset: ShaderPreset<SpiralParams> = {
+  name: 'Droplet',
+  params: {
+    ...defaultPatternSizing,
+    colorBack: '#effafe',
+    colorFront: '#bf40a0',
+    density: 0.9,
+    distortion: 0,
+    strokeWidth: 0.75,
+    strokeTaper: 0.18,
+    strokeCap: 1,
+    noise: 0.74,
+    noiseFrequency: 0.33,
+    softness: 0.02,
+    speed: 1,
+    frame: 0,
+  },
+};
+
+const spiralJunglePreset: ShaderPreset<SpiralParams> = {
+  name: 'Jungle',
+  params: {
+    ...defaultPatternSizing,
+    scale: 1.3,
+    density: 0.5,
+    colorBack: '#a0ef2a',
+    colorFront: '#288b18',
+    distortion: 0,
+    strokeWidth: 0.5,
+    strokeTaper: 0,
+    strokeCap: 0,
+    noise: 1,
+    noiseFrequency: 0.25,
+    softness: 0,
+    speed: 0.75,
+    frame: 0,
+  },
+};
+
+const spiralSwirlPreset: ShaderPreset<SpiralParams> = {
+  name: 'Swirl',
+  params: {
+    ...defaultPatternSizing,
+    scale: 0.45,
+    colorBack: '#b3e6d9',
+    colorFront: '#1a2b4d',
+    density: 0.2,
+    distortion: 0,
+    strokeWidth: 0.5,
+    strokeTaper: 0,
+    strokeCap: 0,
+    noise: 0,
+    noiseFrequency: 0.3,
+    softness: 0.5,
+    speed: 1,
+    frame: 0,
+  },
+};
+
+export const spiralPresets = [
+  spiralDefaultPreset,
+  spiralJunglePreset,
+  spiralDropletPreset,
+  spiralSwirlPreset,
+] satisfies ShaderPreset<SpiralParams>[];
+
+export const Spiral = createShaderComponent<SpiralProps>(
+  'Spiral',
+  shaderComponentPropNames(spiralDefaultPreset.params),
+  ({
+    speed = spiralDefaultPreset.params.speed,
+    frame = spiralDefaultPreset.params.frame,
+    colorBack = spiralDefaultPreset.params.colorBack,
+    colorFront = spiralDefaultPreset.params.colorFront,
+    density = spiralDefaultPreset.params.density,
+    distortion = spiralDefaultPreset.params.distortion,
+    strokeWidth = spiralDefaultPreset.params.strokeWidth,
+    strokeTaper = spiralDefaultPreset.params.strokeTaper,
+    strokeCap = spiralDefaultPreset.params.strokeCap,
+    noiseFrequency = spiralDefaultPreset.params.noiseFrequency,
+    noise = spiralDefaultPreset.params.noise,
+    softness = spiralDefaultPreset.params.softness,
+    fit = spiralDefaultPreset.params.fit,
+    rotation = spiralDefaultPreset.params.rotation,
+    scale = spiralDefaultPreset.params.scale,
+    originX = spiralDefaultPreset.params.originX,
+    originY = spiralDefaultPreset.params.originY,
+    offsetX = spiralDefaultPreset.params.offsetX,
+    offsetY = spiralDefaultPreset.params.offsetY,
+    worldWidth = spiralDefaultPreset.params.worldWidth,
+    worldHeight = spiralDefaultPreset.params.worldHeight,
+    ...props
+  }: SpiralProps) => {
+    const uniforms = {
+      u_colorBack: getShaderColorFromString(colorBack),
+      u_colorFront: getShaderColorFromString(colorFront),
+      u_density: density,
+      u_distortion: distortion,
+      u_strokeWidth: strokeWidth,
+      u_strokeTaper: strokeTaper,
+      u_strokeCap: strokeCap,
+      u_noiseFrequency: noiseFrequency,
+      u_noise: noise,
+      u_softness: softness,
+      u_fit: ShaderFitOptions[fit],
+      u_scale: scale,
+      u_rotation: rotation,
+      u_offsetX: offsetX,
+      u_offsetY: offsetY,
+      u_originX: originX,
+      u_originY: originY,
+      u_worldWidth: worldWidth,
+      u_worldHeight: worldHeight,
+    } satisfies SpiralUniforms;
+
+    return {
+      ...props,
+      speed,
+      frame,
+      fragmentShader: spiralFragmentShader,
+      uniforms,
+    };
+  }
+);
+
+export interface SwirlProps extends ShaderComponentProps, SwirlParams {}
+
+const swirlDefaultPreset: ShaderPreset<SwirlParams> = {
+  name: 'Default',
+  params: {
+    ...defaultObjectSizing,
+    speed: 0.32,
+    frame: 0,
+    colorBack: '#330000',
+    colors: ['#ffd1d1', '#ff8a8a', '#660000'],
+    bandCount: 4,
+    twist: 0.1,
+    center: 0.2,
+    proportion: 0.5,
+    softness: 0,
+    noiseFrequency: 0.4,
+    noise: 0.2,
+  },
+};
+
+const swirlOpeningPreset: ShaderPreset<SwirlParams> = {
+  name: 'Opening',
+  params: {
+    ...defaultObjectSizing,
+    offsetX: -0.4,
+    offsetY: 1,
+    speed: 0.5,
+    frame: 0,
+    colorBack: '#ff8b61',
+    colors: ['#fefff0', '#ffd8bd', '#ff8b61'],
+    bandCount: 2,
+    twist: 0.3,
+    center: 0.2,
+    proportion: 0.5,
+    softness: 0,
+    noiseFrequency: 0,
+    noise: 0,
+    scale: 1,
+  },
+};
+
+const swirlJamesBondPreset: ShaderPreset<SwirlParams> = {
+  name: '007',
+  params: {
+    ...defaultObjectSizing,
+    speed: 1,
+    frame: 0,
+    colorBack: '#E9E7DA',
+    colors: ['#000000'],
+    bandCount: 5,
+    twist: 0.3,
+    center: 0,
+    proportion: 0,
+    softness: 0,
+    noiseFrequency: 0.5,
+    noise: 0,
+  },
+};
+
+const swirlCandyPreset: ShaderPreset<SwirlParams> = {
+  name: 'Candy',
+  params: {
+    ...defaultObjectSizing,
+    speed: 1,
+    frame: 0,
+    colorBack: '#ffcd66',
+    colors: ['#6bbceb', '#d7b3ff', '#ff9fff'],
+    bandCount: 2,
+    twist: 0.15,
+    center: 0.2,
+    proportion: 0.5,
+    softness: 1,
+    noiseFrequency: 0.5,
+    noise: 0,
+  },
+};
+
+export const swirlPresets = [
+  swirlDefaultPreset,
+  swirlJamesBondPreset,
+  swirlOpeningPreset,
+  swirlCandyPreset,
+] satisfies ShaderPreset<SwirlParams>[];
+
+export const Swirl = createShaderComponent<SwirlProps>(
+  'Swirl',
+  shaderComponentPropNames(swirlDefaultPreset.params),
+  ({
+    speed = swirlDefaultPreset.params.speed,
+    frame = swirlDefaultPreset.params.frame,
+    colorBack = swirlDefaultPreset.params.colorBack,
+    colors = swirlDefaultPreset.params.colors,
+    bandCount = swirlDefaultPreset.params.bandCount,
+    twist = swirlDefaultPreset.params.twist,
+    center = swirlDefaultPreset.params.center,
+    proportion = swirlDefaultPreset.params.proportion,
+    softness = swirlDefaultPreset.params.softness,
+    noiseFrequency = swirlDefaultPreset.params.noiseFrequency,
+    noise = swirlDefaultPreset.params.noise,
+    fit = swirlDefaultPreset.params.fit,
+    rotation = swirlDefaultPreset.params.rotation,
+    scale = swirlDefaultPreset.params.scale,
+    originX = swirlDefaultPreset.params.originX,
+    originY = swirlDefaultPreset.params.originY,
+    offsetX = swirlDefaultPreset.params.offsetX,
+    offsetY = swirlDefaultPreset.params.offsetY,
+    worldWidth = swirlDefaultPreset.params.worldWidth,
+    worldHeight = swirlDefaultPreset.params.worldHeight,
+    ...props
+  }: SwirlProps) => {
+    const uniforms = {
+      u_colorBack: getShaderColorFromString(colorBack),
+      u_colors: colors.map(getShaderColorFromString),
+      u_colorsCount: colors.length,
+      u_bandCount: bandCount,
+      u_twist: twist,
+      u_center: center,
+      u_proportion: proportion,
+      u_softness: softness,
+      u_noiseFrequency: noiseFrequency,
+      u_noise: noise,
+      u_fit: ShaderFitOptions[fit],
+      u_scale: scale,
+      u_rotation: rotation,
+      u_offsetX: offsetX,
+      u_offsetY: offsetY,
+      u_originX: originX,
+      u_originY: originY,
+      u_worldWidth: worldWidth,
+      u_worldHeight: worldHeight,
+    } satisfies SwirlUniforms;
+
+    return {
+      ...props,
+      speed,
+      frame,
+      fragmentShader: swirlFragmentShader,
+      uniforms,
+    };
+  }
+);
+
+export interface GrainGradientProps extends ShaderComponentProps, GrainGradientParams {}
+
+const grainGradientDefaultPreset: ShaderPreset<GrainGradientParams> = {
+  name: 'Default',
+  params: {
+    ...defaultObjectSizing,
+    speed: 1,
+    frame: 0,
+    colorBack: '#000000',
+    colors: ['#7300ff', '#eba8ff', '#00bfff', '#2a00ff'],
+    softness: 0.5,
+    intensity: 0.5,
+    noise: 0.25,
+    shape: 'corners',
+  },
+};
+
+const grainGradientWavePreset: ShaderPreset<GrainGradientParams> = {
+  name: 'Wave',
+  params: {
+    ...defaultPatternSizing,
+    speed: 1,
+    frame: 0,
+    colorBack: '#000a0f',
+    colors: ['#c4730b', '#bdad5f', '#d8ccc7'],
+    softness: 0.7,
+    intensity: 0.15,
+    noise: 0.5,
+    shape: 'wave',
+  },
+};
+
+const grainGradientDotsPreset: ShaderPreset<GrainGradientParams> = {
+  name: 'Dots',
+  params: {
+    ...defaultPatternSizing,
+    scale: 0.6,
+    speed: 1,
+    frame: 0,
+    colorBack: '#0a0000',
+    colors: ['#6f0000', '#0080ff', '#f2ebc9', '#33cc33'],
+    softness: 1,
+    intensity: 1,
+    noise: 0.7,
+    shape: 'dots',
+  },
+};
+
+const grainGradientTruchetPreset: ShaderPreset<GrainGradientParams> = {
+  name: 'Truchet',
+  params: {
+    ...defaultPatternSizing,
+    speed: 1,
+    frame: 0,
+    colorBack: '#0a0000',
+    colors: ['#6f2200', '#eabb7c', '#39b523'],
+    softness: 0,
+    intensity: 0.2,
+    noise: 1,
+    shape: 'truchet',
+  },
+};
+
+const grainGradientRipplePreset: ShaderPreset<GrainGradientParams> = {
+  name: 'Ripple',
+  params: {
+    ...defaultObjectSizing,
+    scale: 0.5,
+    speed: 1,
+    frame: 0,
+    colorBack: '#140a00',
+    colors: ['#6f2d00', '#88ddae', '#2c0b1d'],
+    softness: 0.5,
+    intensity: 0.5,
+    noise: 0.5,
+    shape: 'ripple',
+  },
+};
+
+const grainGradientBlobPreset: ShaderPreset<GrainGradientParams> = {
+  name: 'Blob',
+  params: {
+    ...defaultObjectSizing,
+    scale: 1.3,
+    speed: 1,
+    frame: 0,
+    colorBack: '#0f0e18',
+    colors: ['#3e6172', '#a49b74', '#568c50'],
+    softness: 0,
+    intensity: 0.15,
+    noise: 0.5,
+    shape: 'blob',
+  },
+};
+
+export const grainGradientPresets = [
+  grainGradientDefaultPreset,
+  grainGradientWavePreset,
+  grainGradientDotsPreset,
+  grainGradientTruchetPreset,
+  grainGradientRipplePreset,
+  grainGradientBlobPreset,
+] satisfies ShaderPreset<GrainGradientParams>[];
+
+export const GrainGradient = createShaderComponent<GrainGradientProps>(
+  'GrainGradient',
+  shaderComponentPropNames(grainGradientDefaultPreset.params),
+  ({
+    speed = grainGradientDefaultPreset.params.speed,
+    frame = grainGradientDefaultPreset.params.frame,
+    colorBack = grainGradientDefaultPreset.params.colorBack,
+    colors = grainGradientDefaultPreset.params.colors,
+    softness = grainGradientDefaultPreset.params.softness,
+    intensity = grainGradientDefaultPreset.params.intensity,
+    noise = grainGradientDefaultPreset.params.noise,
+    shape = grainGradientDefaultPreset.params.shape,
+    fit = grainGradientDefaultPreset.params.fit,
+    scale = grainGradientDefaultPreset.params.scale,
+    rotation = grainGradientDefaultPreset.params.rotation,
+    originX = grainGradientDefaultPreset.params.originX,
+    originY = grainGradientDefaultPreset.params.originY,
+    offsetX = grainGradientDefaultPreset.params.offsetX,
+    offsetY = grainGradientDefaultPreset.params.offsetY,
+    worldWidth = grainGradientDefaultPreset.params.worldWidth,
+    worldHeight = grainGradientDefaultPreset.params.worldHeight,
+    ...props
+  }: GrainGradientProps) => {
+    const uniforms = {
+      u_colorBack: getShaderColorFromString(colorBack),
+      u_colors: colors.map(getShaderColorFromString),
+      u_colorsCount: colors.length,
+      u_softness: softness,
+      u_intensity: intensity,
+      u_noise: noise,
+      u_shape: GrainGradientShapes[shape],
+      u_noiseTexture: getShaderNoiseTexture(),
+      u_fit: ShaderFitOptions[fit],
+      u_scale: scale,
+      u_rotation: rotation,
+      u_offsetX: offsetX,
+      u_offsetY: offsetY,
+      u_originX: originX,
+      u_originY: originY,
+      u_worldWidth: worldWidth,
+      u_worldHeight: worldHeight,
+    } satisfies GrainGradientUniforms;
+
+    return {
+      ...props,
+      speed,
+      frame,
+      fragmentShader: grainGradientFragmentShader,
+      uniforms,
+    };
+  }
+);
+
+export interface PulsingBorderProps extends ShaderComponentProps, PulsingBorderParams {}
+
+const pulsingBorderDefaultPreset: ShaderPreset<PulsingBorderParams> = {
+  name: 'Default',
+  params: {
+    ...defaultObjectSizing,
+    speed: 1,
+    frame: 0,
+    scale: 0.6,
+    colorBack: '#000000',
+    colors: ['#0dc1fd', '#d915ef', '#ff3f2ecc'],
+    roundness: 0.25,
+    thickness: 0.1,
+    margin: 0,
+    marginLeft: 0,
+    marginRight: 0,
+    marginTop: 0,
+    marginBottom: 0,
+    aspectRatio: 'auto',
+    softness: 0.75,
+    intensity: 0.2,
+    bloom: 0.25,
+    spots: 5,
+    spotSize: 0.5,
+    pulse: 0.25,
+    smoke: 0.3,
+    smokeSize: 0.6,
+  },
+};
+
+const pulsingBorderCirclePreset: ShaderPreset<PulsingBorderParams> = {
+  name: 'Circle',
+  params: {
+    ...defaultObjectSizing,
+    aspectRatio: 'square',
+    scale: 0.6,
+    speed: 1,
+    frame: 0,
+    colorBack: '#000000',
+    colors: ['#0dc1fd', '#d915ef', '#ff3f2ecc'],
+    roundness: 1,
+    margin: 0,
+    marginLeft: 0,
+    marginRight: 0,
+    marginTop: 0,
+    marginBottom: 0,
+    thickness: 0,
+    softness: 0.75,
+    intensity: 0.2,
+    bloom: 0.45,
+    spots: 3,
+    spotSize: 0.4,
+    pulse: 0.5,
+    smoke: 1,
+    smokeSize: 0,
+  },
+};
+
+const pulsingBorderNorthernLightsPreset: ShaderPreset<PulsingBorderParams> = {
+  name: 'Northern lights',
+  params: {
+    ...defaultObjectSizing,
+    speed: 0.18,
+    scale: 1.1,
+    frame: 0,
+    colors: ['#4c4794', '#774a7d', '#12694a', '#0aff78', '#4733cc'],
+    colorBack: '#0c182c',
+    roundness: 0,
+    thickness: 1,
+    softness: 1,
+    margin: 0,
+    marginLeft: 0,
+    marginRight: 0,
+    marginTop: 0,
+    marginBottom: 0,
+    aspectRatio: 'auto',
+    intensity: 0.1,
+    bloom: 0.2,
+    spots: 4,
+    spotSize: 0.25,
+    pulse: 0,
+    smoke: 0.32,
+    smokeSize: 0.5,
+  },
+};
+
+const pulsingBorderSolidLinePreset: ShaderPreset<PulsingBorderParams> = {
+  name: 'Solid line',
+  params: {
+    ...defaultObjectSizing,
+    speed: 1,
+    frame: 0,
+    colors: ['#81ADEC'],
+    colorBack: '#00000000',
+    roundness: 0,
+    thickness: 0.05,
+    margin: 0,
+    marginLeft: 0,
+    marginRight: 0,
+    marginTop: 0,
+    marginBottom: 0,
+    aspectRatio: 'auto',
+    softness: 0,
+    intensity: 0,
+    bloom: 0.15,
+    spots: 4,
+    spotSize: 1,
+    pulse: 0,
+    smoke: 0,
+    smokeSize: 0,
+  },
+};
+
+export const pulsingBorderPresets = [
+  pulsingBorderDefaultPreset,
+  pulsingBorderCirclePreset,
+  pulsingBorderNorthernLightsPreset,
+  pulsingBorderSolidLinePreset,
+] satisfies ShaderPreset<PulsingBorderParams>[];
+
+export const PulsingBorder = createShaderComponent<PulsingBorderProps>(
+  'PulsingBorder',
+  shaderComponentPropNames(pulsingBorderDefaultPreset.params),
+  ({
+    speed = pulsingBorderDefaultPreset.params.speed,
+    frame = pulsingBorderDefaultPreset.params.frame,
+    colors = pulsingBorderDefaultPreset.params.colors,
+    colorBack = pulsingBorderDefaultPreset.params.colorBack,
+    roundness = pulsingBorderDefaultPreset.params.roundness,
+    thickness = pulsingBorderDefaultPreset.params.thickness,
+    aspectRatio = pulsingBorderDefaultPreset.params.aspectRatio,
+    softness = pulsingBorderDefaultPreset.params.softness,
+    bloom = pulsingBorderDefaultPreset.params.bloom,
+    intensity = pulsingBorderDefaultPreset.params.intensity,
+    spots = pulsingBorderDefaultPreset.params.spots,
+    spotSize = pulsingBorderDefaultPreset.params.spotSize,
+    pulse = pulsingBorderDefaultPreset.params.pulse,
+    smoke = pulsingBorderDefaultPreset.params.smoke,
+    smokeSize = pulsingBorderDefaultPreset.params.smokeSize,
+    margin,
+    marginLeft = margin ?? pulsingBorderDefaultPreset.params.marginLeft,
+    marginRight = margin ?? pulsingBorderDefaultPreset.params.marginRight,
+    marginTop = margin ?? pulsingBorderDefaultPreset.params.marginTop,
+    marginBottom = margin ?? pulsingBorderDefaultPreset.params.marginBottom,
+    fit = pulsingBorderDefaultPreset.params.fit,
+    rotation = pulsingBorderDefaultPreset.params.rotation,
+    scale = pulsingBorderDefaultPreset.params.scale,
+    originX = pulsingBorderDefaultPreset.params.originX,
+    originY = pulsingBorderDefaultPreset.params.originY,
+    offsetX = pulsingBorderDefaultPreset.params.offsetX,
+    offsetY = pulsingBorderDefaultPreset.params.offsetY,
+    worldWidth = pulsingBorderDefaultPreset.params.worldWidth,
+    worldHeight = pulsingBorderDefaultPreset.params.worldHeight,
+    ...props
+  }: PulsingBorderProps) => {
+    const uniforms = {
+      u_colorBack: getShaderColorFromString(colorBack),
+      u_colors: colors.map(getShaderColorFromString),
+      u_colorsCount: colors.length,
+      u_roundness: roundness,
+      u_thickness: thickness,
+      u_marginLeft: marginLeft,
+      u_marginRight: marginRight,
+      u_marginTop: marginTop,
+      u_marginBottom: marginBottom,
+      u_aspectRatio: PulsingBorderAspectRatios[aspectRatio],
+      u_softness: softness,
+      u_intensity: intensity,
+      u_bloom: bloom,
+      u_spots: spots,
+      u_spotSize: spotSize,
+      u_pulse: pulse,
+      u_smoke: smoke,
+      u_smokeSize: smokeSize,
+      u_noiseTexture: getShaderNoiseTexture(),
+      u_fit: ShaderFitOptions[fit],
+      u_rotation: rotation,
+      u_scale: scale,
+      u_offsetX: offsetX,
+      u_offsetY: offsetY,
+      u_originX: originX,
+      u_originY: originY,
+      u_worldWidth: worldWidth,
+      u_worldHeight: worldHeight,
+    } satisfies PulsingBorderUniforms;
+
+    return {
+      ...props,
+      speed,
+      frame,
+      fragmentShader: pulsingBorderFragmentShader,
+      uniforms,
+    };
+  }
+);

--- a/packages/shaders-vue/src/shaders-image.ts
+++ b/packages/shaders-vue/src/shaders-image.ts
@@ -1,0 +1,1474 @@
+import { defineComponent, h, onBeforeUnmount, onMounted, ref, watch } from 'vue';
+import {
+  DitheringTypes,
+  GlassDistortionShapes,
+  GlassGridShapes,
+  HalftoneCmykTypes,
+  HalftoneDotsGrids,
+  HalftoneDotsTypes,
+  LiquidMetalShapes,
+  ShaderFitOptions,
+  defaultObjectSizing,
+  flutedGlassFragmentShader,
+  getShaderColorFromString,
+  getShaderNoiseTexture,
+  halftoneCmykFragmentShader,
+  halftoneDotsFragmentShader,
+  heatmapFragmentShader,
+  imageDitheringFragmentShader,
+  liquidMetalFragmentShader,
+  paperTextureFragmentShader,
+  toProcessedHeatmap,
+  toProcessedLiquidMetal,
+  waterFragmentShader,
+  type FlutedGlassParams,
+  type FlutedGlassUniforms,
+  type HalftoneCmykParams,
+  type HalftoneCmykUniforms,
+  type HalftoneDotsParams,
+  type HalftoneDotsUniforms,
+  type HeatmapParams,
+  type HeatmapUniforms,
+  type ImageDitheringParams,
+  type ImageDitheringUniforms,
+  type ImageShaderPreset,
+  type LiquidMetalParams,
+  type LiquidMetalUniforms,
+  type PaperTextureParams,
+  type PaperTextureUniforms,
+  type WaterParams,
+  type WaterUniforms,
+} from '@paper-design/shaders';
+import { createShaderComponent, shaderComponentPropNames } from './create-shader-component.js';
+import { ShaderMount } from './shader-mount.js';
+import type { ShaderComponentProps } from './shader-mount.js';
+
+const transparentPixel = 'data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==';
+
+function toImageUrl(image: string | HTMLImageElement | undefined): string {
+  if (typeof image === 'string') {
+    return image;
+  }
+
+  return image?.src ?? '';
+}
+
+function useProcessedImage(
+  getImageUrl: () => string,
+  label: string,
+  process: (imageUrl: string) => Promise<Blob>
+) {
+  const processedImage = ref<string>(transparentPixel);
+  let currentObjectUrl: string | null = null;
+  let requestId = 0;
+  let stopWatcher: (() => void) | undefined;
+
+  const revokeCurrentUrl = (): void => {
+    if (currentObjectUrl !== null) {
+      URL.revokeObjectURL(currentObjectUrl);
+      currentObjectUrl = null;
+    }
+  };
+
+  onMounted(() => {
+    stopWatcher = watch(
+      getImageUrl,
+      async (imageUrl) => {
+        const currentRequestId = ++requestId;
+        revokeCurrentUrl();
+
+        if (!imageUrl) {
+          processedImage.value = transparentPixel;
+          return;
+        }
+
+        try {
+          const objectUrl = URL.createObjectURL(await process(imageUrl));
+
+          if (currentRequestId !== requestId) {
+            URL.revokeObjectURL(objectUrl);
+            return;
+          }
+
+          currentObjectUrl = objectUrl;
+          processedImage.value = objectUrl;
+        } catch (error) {
+          if (currentRequestId === requestId) {
+            processedImage.value = transparentPixel;
+          }
+
+          console.error(`Could not process ${label} image`, error);
+        }
+      },
+      { immediate: true }
+    );
+  });
+
+  onBeforeUnmount(() => {
+    requestId += 1;
+    stopWatcher?.();
+    revokeCurrentUrl();
+  });
+
+  return processedImage;
+}
+
+export interface FlutedGlassProps extends ShaderComponentProps, FlutedGlassParams {
+  count?: number;
+}
+
+const flutedGlassDefaultPreset: ImageShaderPreset<FlutedGlassParams> = {
+  name: 'Default',
+  params: {
+    ...defaultObjectSizing,
+    fit: 'cover',
+    speed: 0,
+    frame: 0,
+    colorBack: '#00000000',
+    colorShadow: '#000000',
+    colorHighlight: '#ffffff',
+    shadows: 0.25,
+    size: 0.5,
+    angle: 0,
+    distortionShape: 'prism',
+    highlights: 0.1,
+    shape: 'lines',
+    distortion: 0.5,
+    shift: 0,
+    blur: 0,
+    edges: 0.25,
+    stretch: 0,
+    margin: 0,
+    marginLeft: 0,
+    marginRight: 0,
+    marginTop: 0,
+    marginBottom: 0,
+    grainMixer: 0,
+    grainOverlay: 0,
+  },
+};
+
+const flutedGlassWavesPreset: ImageShaderPreset<FlutedGlassParams> = {
+  name: 'Waves',
+  params: {
+    ...defaultObjectSizing,
+    fit: 'cover',
+    scale: 1.2,
+    speed: 0,
+    frame: 0,
+    colorBack: '#00000000',
+    colorShadow: '#000000',
+    colorHighlight: '#ffffff',
+    shadows: 0,
+    size: 0.9,
+    angle: 0,
+    distortionShape: 'contour',
+    highlights: 0,
+    shape: 'wave',
+    distortion: 0.5,
+    shift: 0,
+    blur: 0.1,
+    edges: 0.5,
+    stretch: 1,
+    margin: 0,
+    marginLeft: 0,
+    marginRight: 0,
+    marginTop: 0,
+    marginBottom: 0,
+    grainMixer: 0,
+    grainOverlay: 0.05,
+  },
+};
+
+const flutedGlassAbstractPreset: ImageShaderPreset<FlutedGlassParams> = {
+  name: 'Abstract',
+  params: {
+    ...defaultObjectSizing,
+    fit: 'cover',
+    scale: 4,
+    speed: 0,
+    frame: 0,
+    colorBack: '#00000000',
+    colorShadow: '#000000',
+    colorHighlight: '#ffffff',
+    shadows: 0,
+    size: 0.7,
+    angle: 30,
+    distortionShape: 'flat',
+    highlights: 0,
+    shape: 'linesIrregular',
+    distortion: 1,
+    shift: 0,
+    blur: 1,
+    edges: 0.5,
+    stretch: 1,
+    margin: 0,
+    marginLeft: 0,
+    marginRight: 0,
+    marginTop: 0,
+    marginBottom: 0,
+    grainMixer: 0.1,
+    grainOverlay: 0.1,
+  },
+};
+
+const flutedGlassFoldsPreset: ImageShaderPreset<FlutedGlassParams> = {
+  name: 'Folds',
+  params: {
+    ...defaultObjectSizing,
+    fit: 'cover',
+    speed: 0,
+    frame: 0,
+    colorBack: '#00000000',
+    colorShadow: '#000000',
+    colorHighlight: '#ffffff',
+    shadows: 0.4,
+    size: 0.4,
+    angle: 0,
+    distortionShape: 'cascade',
+    highlights: 0,
+    shape: 'lines',
+    distortion: 0.75,
+    shift: 0,
+    blur: 0.25,
+    edges: 0.5,
+    stretch: 0,
+    margin: 0.1,
+    marginLeft: 0.1,
+    marginRight: 0.1,
+    marginTop: 0.1,
+    marginBottom: 0.1,
+    grainMixer: 0,
+    grainOverlay: 0,
+  },
+};
+
+export const flutedGlassPresets = [
+  flutedGlassDefaultPreset,
+  flutedGlassAbstractPreset,
+  flutedGlassWavesPreset,
+  flutedGlassFoldsPreset,
+] satisfies ImageShaderPreset<FlutedGlassParams>[];
+
+export const FlutedGlass = createShaderComponent<FlutedGlassProps>(
+  'FlutedGlass',
+  shaderComponentPropNames(flutedGlassDefaultPreset.params, ['count']),
+  ({
+    speed = flutedGlassDefaultPreset.params.speed,
+    frame = flutedGlassDefaultPreset.params.frame,
+    colorBack = flutedGlassDefaultPreset.params.colorBack,
+    colorShadow = flutedGlassDefaultPreset.params.colorShadow,
+    colorHighlight = flutedGlassDefaultPreset.params.colorHighlight,
+    image = '',
+    shadows = flutedGlassDefaultPreset.params.shadows,
+    angle = flutedGlassDefaultPreset.params.angle,
+    distortion = flutedGlassDefaultPreset.params.distortion,
+    distortionShape = flutedGlassDefaultPreset.params.distortionShape,
+    highlights = flutedGlassDefaultPreset.params.highlights,
+    shape = flutedGlassDefaultPreset.params.shape,
+    shift = flutedGlassDefaultPreset.params.shift,
+    blur = flutedGlassDefaultPreset.params.blur,
+    edges = flutedGlassDefaultPreset.params.edges,
+    margin,
+    marginLeft = margin ?? flutedGlassDefaultPreset.params.marginLeft,
+    marginRight = margin ?? flutedGlassDefaultPreset.params.marginRight,
+    marginTop = margin ?? flutedGlassDefaultPreset.params.marginTop,
+    marginBottom = margin ?? flutedGlassDefaultPreset.params.marginBottom,
+    grainMixer = flutedGlassDefaultPreset.params.grainMixer,
+    grainOverlay = flutedGlassDefaultPreset.params.grainOverlay,
+    stretch = flutedGlassDefaultPreset.params.stretch,
+    count,
+    size = count === undefined ? flutedGlassDefaultPreset.params.size : Math.pow(1 / (count * 1.6), 1 / 6) / 0.7 - 0.5,
+    fit = flutedGlassDefaultPreset.params.fit,
+    scale = flutedGlassDefaultPreset.params.scale,
+    rotation = flutedGlassDefaultPreset.params.rotation,
+    originX = flutedGlassDefaultPreset.params.originX,
+    originY = flutedGlassDefaultPreset.params.originY,
+    offsetX = flutedGlassDefaultPreset.params.offsetX,
+    offsetY = flutedGlassDefaultPreset.params.offsetY,
+    worldWidth = flutedGlassDefaultPreset.params.worldWidth,
+    worldHeight = flutedGlassDefaultPreset.params.worldHeight,
+    ...props
+  }: FlutedGlassProps) => {
+    const uniforms = {
+      u_image: image,
+      u_colorBack: getShaderColorFromString(colorBack),
+      u_colorShadow: getShaderColorFromString(colorShadow),
+      u_colorHighlight: getShaderColorFromString(colorHighlight),
+      u_shadows: shadows,
+      u_size: size,
+      u_angle: angle,
+      u_distortion: distortion,
+      u_shift: shift,
+      u_blur: blur,
+      u_edges: edges,
+      u_stretch: stretch,
+      u_distortionShape: GlassDistortionShapes[distortionShape],
+      u_highlights: highlights,
+      u_shape: GlassGridShapes[shape],
+      u_marginLeft: marginLeft,
+      u_marginRight: marginRight,
+      u_marginTop: marginTop,
+      u_marginBottom: marginBottom,
+      u_grainMixer: grainMixer,
+      u_grainOverlay: grainOverlay,
+      u_fit: ShaderFitOptions[fit],
+      u_scale: scale,
+      u_rotation: rotation,
+      u_offsetX: offsetX,
+      u_offsetY: offsetY,
+      u_originX: originX,
+      u_originY: originY,
+      u_worldWidth: worldWidth,
+      u_worldHeight: worldHeight,
+    } satisfies FlutedGlassUniforms;
+
+    return {
+      ...props,
+      speed,
+      frame,
+      fragmentShader: flutedGlassFragmentShader,
+      mipmaps: ['u_image'],
+      uniforms,
+    };
+  }
+);
+
+export interface PaperTextureProps extends ShaderComponentProps, PaperTextureParams {
+  fiberScale?: number;
+  crumplesScale?: number;
+  foldsNumber?: number;
+  blur?: number;
+}
+
+const paperTextureDefaultPreset: ImageShaderPreset<PaperTextureParams> = {
+  name: 'Default',
+  params: {
+    ...defaultObjectSizing,
+    fit: 'cover',
+    scale: 0.6,
+    speed: 0,
+    frame: 0,
+    colorFront: '#9fadbc',
+    colorBack: '#ffffff',
+    contrast: 0.3,
+    roughness: 0.4,
+    fiber: 0.3,
+    fiberSize: 0.2,
+    crumples: 0.3,
+    crumpleSize: 0.35,
+    folds: 0.65,
+    foldCount: 5,
+    fade: 0,
+    drops: 0.2,
+    seed: 5.8,
+  },
+};
+
+const paperTextureAbstractPreset: ImageShaderPreset<PaperTextureParams> = {
+  name: 'Abstract',
+  params: {
+    ...defaultObjectSizing,
+    fit: 'cover',
+    speed: 0,
+    frame: 0,
+    scale: 0.6,
+    colorFront: '#00eeff',
+    colorBack: '#ff0a81',
+    contrast: 0.85,
+    roughness: 0,
+    fiber: 0.1,
+    fiberSize: 0.2,
+    crumples: 0,
+    crumpleSize: 0.3,
+    folds: 1,
+    foldCount: 3,
+    fade: 0,
+    drops: 0.2,
+    seed: 2.2,
+  },
+};
+
+const paperTextureCardboardPreset: ImageShaderPreset<PaperTextureParams> = {
+  name: 'Cardboard',
+  params: {
+    ...defaultObjectSizing,
+    fit: 'cover',
+    speed: 0,
+    frame: 0,
+    scale: 0.6,
+    colorFront: '#c7b89e',
+    colorBack: '#999180',
+    contrast: 0.4,
+    roughness: 0,
+    fiber: 0.35,
+    fiberSize: 0.14,
+    crumples: 0.7,
+    crumpleSize: 0.1,
+    folds: 0,
+    foldCount: 1,
+    fade: 0,
+    drops: 0.1,
+    seed: 1.6,
+  },
+};
+
+const paperTextureDetailsPreset: ImageShaderPreset<PaperTextureParams> = {
+  name: 'Details',
+  params: {
+    ...defaultObjectSizing,
+    speed: 0,
+    frame: 0,
+    fit: 'cover',
+    scale: 3,
+    colorFront: '#00000000',
+    colorBack: '#00000000',
+    contrast: 0,
+    roughness: 1,
+    fiber: 0.27,
+    fiberSize: 0.22,
+    crumples: 1,
+    crumpleSize: 0.5,
+    folds: 1,
+    foldCount: 15,
+    fade: 0,
+    drops: 0,
+    seed: 6,
+  },
+};
+
+export const paperTexturePresets = [
+  paperTextureDefaultPreset,
+  paperTextureCardboardPreset,
+  paperTextureAbstractPreset,
+  paperTextureDetailsPreset,
+] satisfies ImageShaderPreset<PaperTextureParams>[];
+
+export const PaperTexture = createShaderComponent<PaperTextureProps>(
+  'PaperTexture',
+  shaderComponentPropNames(paperTextureDefaultPreset.params, ['fiberScale', 'crumplesScale', 'foldsNumber', 'blur']),
+  ({
+    speed = paperTextureDefaultPreset.params.speed,
+    frame = paperTextureDefaultPreset.params.frame,
+    colorFront = paperTextureDefaultPreset.params.colorFront,
+    colorBack = paperTextureDefaultPreset.params.colorBack,
+    image = '',
+    contrast = paperTextureDefaultPreset.params.contrast,
+    roughness = paperTextureDefaultPreset.params.roughness,
+    fiber = paperTextureDefaultPreset.params.fiber,
+    crumples = paperTextureDefaultPreset.params.crumples,
+    folds = paperTextureDefaultPreset.params.folds,
+    drops = paperTextureDefaultPreset.params.drops,
+    seed = paperTextureDefaultPreset.params.seed,
+    fiberScale,
+    fiberSize = fiberScale === undefined ? paperTextureDefaultPreset.params.fiberSize : 0.2 / fiberScale,
+    crumplesScale,
+    crumpleSize = crumplesScale === undefined ? paperTextureDefaultPreset.params.crumpleSize : 0.2 / crumplesScale,
+    blur,
+    fade = blur === undefined ? paperTextureDefaultPreset.params.fade : blur,
+    foldsNumber,
+    foldCount = foldsNumber === undefined ? paperTextureDefaultPreset.params.foldCount : foldsNumber,
+    fit = paperTextureDefaultPreset.params.fit,
+    scale = paperTextureDefaultPreset.params.scale,
+    rotation = paperTextureDefaultPreset.params.rotation,
+    originX = paperTextureDefaultPreset.params.originX,
+    originY = paperTextureDefaultPreset.params.originY,
+    offsetX = paperTextureDefaultPreset.params.offsetX,
+    offsetY = paperTextureDefaultPreset.params.offsetY,
+    worldWidth = paperTextureDefaultPreset.params.worldWidth,
+    worldHeight = paperTextureDefaultPreset.params.worldHeight,
+    ...props
+  }: PaperTextureProps) => {
+    const noiseTexture = typeof window !== 'undefined' ? { u_noiseTexture: getShaderNoiseTexture() } : {};
+
+    const uniforms = {
+      u_image: image,
+      u_colorFront: getShaderColorFromString(colorFront),
+      u_colorBack: getShaderColorFromString(colorBack),
+      u_contrast: contrast,
+      u_roughness: roughness,
+      u_fiber: fiber,
+      u_fiberSize: fiberSize,
+      u_crumples: crumples,
+      u_crumpleSize: crumpleSize,
+      u_foldCount: foldCount,
+      u_folds: folds,
+      u_fade: fade,
+      u_drops: drops,
+      u_seed: seed,
+      ...noiseTexture,
+      u_fit: ShaderFitOptions[fit],
+      u_scale: scale,
+      u_rotation: rotation,
+      u_offsetX: offsetX,
+      u_offsetY: offsetY,
+      u_originX: originX,
+      u_originY: originY,
+      u_worldWidth: worldWidth,
+      u_worldHeight: worldHeight,
+    } satisfies PaperTextureUniforms;
+
+    return {
+      ...props,
+      speed,
+      frame,
+      fragmentShader: paperTextureFragmentShader,
+      mipmaps: ['u_image'],
+      uniforms,
+    };
+  }
+);
+
+export interface WaterProps extends ShaderComponentProps, WaterParams {
+  effectScale?: number;
+}
+
+const waterDefaultPreset: ImageShaderPreset<WaterParams> = {
+  name: 'Default',
+  params: {
+    ...defaultObjectSizing,
+    scale: 0.8,
+    speed: 1,
+    frame: 0,
+    colorBack: '#909090',
+    colorHighlight: '#ffffff',
+    highlights: 0.07,
+    layering: 0.5,
+    edges: 0.8,
+    waves: 0.3,
+    caustic: 0.1,
+    size: 1,
+  },
+};
+
+const waterAbstractPreset: ImageShaderPreset<WaterParams> = {
+  name: 'Abstract',
+  params: {
+    ...defaultObjectSizing,
+    fit: 'cover',
+    scale: 3,
+    speed: 1,
+    frame: 0,
+    colorBack: '#909090',
+    colorHighlight: '#ffffff',
+    highlights: 0,
+    layering: 0,
+    edges: 1,
+    waves: 1,
+    caustic: 0.4,
+    size: 0.15,
+  },
+};
+
+const waterStreamingPreset: ImageShaderPreset<WaterParams> = {
+  name: 'Streaming',
+  params: {
+    ...defaultObjectSizing,
+    fit: 'contain',
+    scale: 0.4,
+    speed: 2,
+    frame: 0,
+    colorBack: '#909090',
+    colorHighlight: '#ffffff',
+    highlights: 0,
+    layering: 0,
+    edges: 0,
+    waves: 0.5,
+    caustic: 0,
+    size: 0.5,
+  },
+};
+
+const waterSlowMoPreset: ImageShaderPreset<WaterParams> = {
+  name: 'Slow-mo',
+  params: {
+    ...defaultObjectSizing,
+    fit: 'cover',
+    scale: 1,
+    speed: 0.1,
+    frame: 0,
+    colorBack: '#909090',
+    colorHighlight: '#ffffff',
+    highlights: 0.4,
+    layering: 0,
+    edges: 0,
+    waves: 0,
+    caustic: 0.2,
+    size: 0.7,
+  },
+};
+
+export const waterPresets = [
+  waterDefaultPreset,
+  waterSlowMoPreset,
+  waterAbstractPreset,
+  waterStreamingPreset,
+] satisfies ImageShaderPreset<WaterParams>[];
+
+export const Water = createShaderComponent<WaterProps>(
+  'Water',
+  shaderComponentPropNames(waterDefaultPreset.params, ['effectScale']),
+  ({
+    speed = waterDefaultPreset.params.speed,
+    frame = waterDefaultPreset.params.frame,
+    colorBack = waterDefaultPreset.params.colorBack,
+    colorHighlight = waterDefaultPreset.params.colorHighlight,
+    image = '',
+    highlights = waterDefaultPreset.params.highlights,
+    layering = waterDefaultPreset.params.layering,
+    waves = waterDefaultPreset.params.waves,
+    edges = waterDefaultPreset.params.edges,
+    caustic = waterDefaultPreset.params.caustic,
+    effectScale,
+    size = effectScale === undefined ? waterDefaultPreset.params.size : 10 / 9 / effectScale - 1 / 9,
+    fit = waterDefaultPreset.params.fit,
+    scale = waterDefaultPreset.params.scale,
+    rotation = waterDefaultPreset.params.rotation,
+    originX = waterDefaultPreset.params.originX,
+    originY = waterDefaultPreset.params.originY,
+    offsetX = waterDefaultPreset.params.offsetX,
+    offsetY = waterDefaultPreset.params.offsetY,
+    worldWidth = waterDefaultPreset.params.worldWidth,
+    worldHeight = waterDefaultPreset.params.worldHeight,
+    ...props
+  }: WaterProps) => {
+    const uniforms = {
+      u_image: image,
+      u_colorBack: getShaderColorFromString(colorBack),
+      u_colorHighlight: getShaderColorFromString(colorHighlight),
+      u_highlights: highlights,
+      u_layering: layering,
+      u_waves: waves,
+      u_edges: edges,
+      u_caustic: caustic,
+      u_size: size,
+      u_fit: ShaderFitOptions[fit],
+      u_rotation: rotation,
+      u_scale: scale,
+      u_offsetX: offsetX,
+      u_offsetY: offsetY,
+      u_originX: originX,
+      u_originY: originY,
+      u_worldWidth: worldWidth,
+      u_worldHeight: worldHeight,
+    } satisfies WaterUniforms;
+
+    return {
+      ...props,
+      speed,
+      frame,
+      fragmentShader: waterFragmentShader,
+      mipmaps: ['u_image'],
+      uniforms,
+    };
+  }
+);
+
+export interface ImageDitheringProps extends ShaderComponentProps, ImageDitheringParams {
+  pxSize?: number;
+}
+
+const imageDitheringDefaultPreset: ImageShaderPreset<ImageDitheringParams> = {
+  name: 'Default',
+  params: {
+    ...defaultObjectSizing,
+    fit: 'cover',
+    speed: 0,
+    frame: 0,
+    colorFront: '#94ffaf',
+    colorBack: '#000c38',
+    colorHighlight: '#eaff94',
+    type: '8x8',
+    size: 2,
+    colorSteps: 2,
+    originalColors: false,
+    inverted: false,
+  },
+};
+
+const imageDitheringRetroPreset: ImageShaderPreset<ImageDitheringParams> = {
+  name: 'Retro',
+  params: {
+    ...defaultObjectSizing,
+    fit: 'cover',
+    speed: 0,
+    frame: 0,
+    colorFront: '#eeeeee',
+    colorBack: '#5452ff',
+    colorHighlight: '#eeeeee',
+    type: '2x2',
+    size: 3,
+    colorSteps: 1,
+    originalColors: true,
+    inverted: false,
+  },
+};
+
+const imageDitheringNoisePreset: ImageShaderPreset<ImageDitheringParams> = {
+  name: 'Noise',
+  params: {
+    ...defaultObjectSizing,
+    fit: 'cover',
+    speed: 0,
+    frame: 0,
+    colorFront: '#a2997c',
+    colorBack: '#000000',
+    colorHighlight: '#ededed',
+    type: 'random',
+    size: 1,
+    colorSteps: 1,
+    originalColors: false,
+    inverted: false,
+  },
+};
+
+const imageDitheringNaturalPreset: ImageShaderPreset<ImageDitheringParams> = {
+  name: 'Natural',
+  params: {
+    ...defaultObjectSizing,
+    fit: 'cover',
+    speed: 0,
+    frame: 0,
+    colorFront: '#ffffff',
+    colorBack: '#000000',
+    colorHighlight: '#ffffff',
+    type: '8x8',
+    size: 2,
+    colorSteps: 5,
+    originalColors: true,
+    inverted: false,
+  },
+};
+
+export const imageDitheringPresets = [
+  imageDitheringDefaultPreset,
+  imageDitheringNoisePreset,
+  imageDitheringRetroPreset,
+  imageDitheringNaturalPreset,
+] satisfies ImageShaderPreset<ImageDitheringParams>[];
+
+export const ImageDithering = createShaderComponent<ImageDitheringProps>(
+  'ImageDithering',
+  shaderComponentPropNames(imageDitheringDefaultPreset.params, ['pxSize']),
+  ({
+    speed = imageDitheringDefaultPreset.params.speed,
+    frame = imageDitheringDefaultPreset.params.frame,
+    colorFront = imageDitheringDefaultPreset.params.colorFront,
+    colorBack = imageDitheringDefaultPreset.params.colorBack,
+    colorHighlight = imageDitheringDefaultPreset.params.colorHighlight,
+    image = '',
+    type = imageDitheringDefaultPreset.params.type,
+    colorSteps = imageDitheringDefaultPreset.params.colorSteps,
+    originalColors = imageDitheringDefaultPreset.params.originalColors,
+    inverted = imageDitheringDefaultPreset.params.inverted,
+    pxSize,
+    size = pxSize === undefined ? imageDitheringDefaultPreset.params.size : pxSize,
+    fit = imageDitheringDefaultPreset.params.fit,
+    scale = imageDitheringDefaultPreset.params.scale,
+    rotation = imageDitheringDefaultPreset.params.rotation,
+    originX = imageDitheringDefaultPreset.params.originX,
+    originY = imageDitheringDefaultPreset.params.originY,
+    offsetX = imageDitheringDefaultPreset.params.offsetX,
+    offsetY = imageDitheringDefaultPreset.params.offsetY,
+    worldWidth = imageDitheringDefaultPreset.params.worldWidth,
+    worldHeight = imageDitheringDefaultPreset.params.worldHeight,
+    ...props
+  }: ImageDitheringProps) => {
+    const uniforms = {
+      u_image: image,
+      u_colorFront: getShaderColorFromString(colorFront),
+      u_colorBack: getShaderColorFromString(colorBack),
+      u_colorHighlight: getShaderColorFromString(colorHighlight),
+      u_type: DitheringTypes[type],
+      u_pxSize: size,
+      u_colorSteps: colorSteps,
+      u_originalColors: originalColors,
+      u_inverted: inverted,
+      u_fit: ShaderFitOptions[fit],
+      u_rotation: rotation,
+      u_scale: scale,
+      u_offsetX: offsetX,
+      u_offsetY: offsetY,
+      u_originX: originX,
+      u_originY: originY,
+      u_worldWidth: worldWidth,
+      u_worldHeight: worldHeight,
+    } satisfies ImageDitheringUniforms;
+
+    return {
+      ...props,
+      speed,
+      frame,
+      fragmentShader: imageDitheringFragmentShader,
+      uniforms,
+    };
+  }
+);
+
+export interface HeatmapProps extends ShaderComponentProps, HeatmapParams {
+  suspendWhenProcessingImage?: boolean;
+}
+
+const heatmapDefaultPreset: ImageShaderPreset<HeatmapParams> = {
+  name: 'Default',
+  params: {
+    ...defaultObjectSizing,
+    scale: 0.75,
+    speed: 1,
+    frame: 0,
+    contour: 0.5,
+    angle: 0,
+    noise: 0,
+    innerGlow: 0.5,
+    outerGlow: 0.5,
+    colorBack: '#000000',
+    colors: ['#11206a', '#1f3ba2', '#2f63e7', '#6bd7ff', '#ffe679', '#ff991e', '#ff4c00'],
+  },
+};
+
+const heatmapSepiaPreset: ImageShaderPreset<HeatmapParams> = {
+  name: 'Sepia',
+  params: {
+    ...defaultObjectSizing,
+    scale: 0.75,
+    speed: 0.5,
+    frame: 0,
+    contour: 0.5,
+    angle: 0,
+    noise: 0.75,
+    innerGlow: 0.5,
+    outerGlow: 0.5,
+    colorBack: '#000000',
+    colors: ['#997F45', '#ffffff'],
+  },
+};
+
+export const heatmapPresets = [heatmapDefaultPreset, heatmapSepiaPreset] satisfies ImageShaderPreset<HeatmapParams>[];
+
+const heatmapPropNames = shaderComponentPropNames(heatmapDefaultPreset.params, ['image', 'suspendWhenProcessingImage']);
+
+export const Heatmap = defineComponent({
+  name: 'Heatmap',
+  inheritAttrs: false,
+  props: heatmapPropNames,
+  setup(rawProps, { attrs }) {
+    const props = rawProps as unknown as HeatmapProps;
+    const processedImage = useProcessedImage(
+      () => toImageUrl(props.image),
+      'heatmap',
+      async (imageUrl) => (await toProcessedHeatmap(imageUrl)).blob
+    );
+
+    return () => {
+      const {
+        speed = heatmapDefaultPreset.params.speed,
+        frame = heatmapDefaultPreset.params.frame,
+        image: _image = '',
+        contour = heatmapDefaultPreset.params.contour,
+        angle = heatmapDefaultPreset.params.angle,
+        noise = heatmapDefaultPreset.params.noise,
+        innerGlow = heatmapDefaultPreset.params.innerGlow,
+        outerGlow = heatmapDefaultPreset.params.outerGlow,
+        colorBack = heatmapDefaultPreset.params.colorBack,
+        colors = heatmapDefaultPreset.params.colors,
+        suspendWhenProcessingImage: _suspendWhenProcessingImage = false,
+        fit = heatmapDefaultPreset.params.fit,
+        offsetX = heatmapDefaultPreset.params.offsetX,
+        offsetY = heatmapDefaultPreset.params.offsetY,
+        originX = heatmapDefaultPreset.params.originX,
+        originY = heatmapDefaultPreset.params.originY,
+        rotation = heatmapDefaultPreset.params.rotation,
+        scale = heatmapDefaultPreset.params.scale,
+        worldHeight = heatmapDefaultPreset.params.worldHeight,
+        worldWidth = heatmapDefaultPreset.params.worldWidth,
+        ...shaderProps
+      } = props;
+
+      const uniforms = {
+        u_image: processedImage.value,
+        u_contour: contour,
+        u_angle: angle,
+        u_noise: noise,
+        u_innerGlow: innerGlow,
+        u_outerGlow: outerGlow,
+        u_colorBack: getShaderColorFromString(colorBack),
+        u_colors: colors.map(getShaderColorFromString),
+        u_colorsCount: colors.length,
+        u_fit: ShaderFitOptions[fit],
+        u_offsetX: offsetX,
+        u_offsetY: offsetY,
+        u_originX: originX,
+        u_originY: originY,
+        u_rotation: rotation,
+        u_scale: scale,
+        u_worldHeight: worldHeight,
+        u_worldWidth: worldWidth,
+      } satisfies HeatmapUniforms;
+
+      return h(ShaderMount, {
+        ...attrs,
+        ...shaderProps,
+        speed,
+        frame,
+        fragmentShader: heatmapFragmentShader,
+        mipmaps: ['u_image'],
+        uniforms,
+      });
+    };
+  },
+});
+
+export interface LiquidMetalProps extends ShaderComponentProps, LiquidMetalParams {
+  suspendWhenProcessingImage?: boolean;
+}
+
+const liquidMetalDefaultPreset: ImageShaderPreset<LiquidMetalParams> = {
+  name: 'Default',
+  params: {
+    ...defaultObjectSizing,
+    scale: 0.6,
+    speed: 1,
+    frame: 0,
+    colorBack: '#AAAAAC',
+    colorTint: '#ffffff',
+    distortion: 0.07,
+    repetition: 2,
+    shiftRed: 0.3,
+    shiftBlue: 0.3,
+    contour: 0.4,
+    softness: 0.1,
+    angle: 70,
+    shape: 'diamond',
+  },
+};
+
+const liquidMetalNoirPreset: ImageShaderPreset<LiquidMetalParams> = {
+  name: 'Noir',
+  params: {
+    ...defaultObjectSizing,
+    scale: 0.6,
+    speed: 1,
+    frame: 0,
+    colorBack: '#000000',
+    colorTint: '#606060',
+    softness: 0.45,
+    repetition: 1.5,
+    shiftRed: 0,
+    shiftBlue: 0,
+    distortion: 0,
+    contour: 0,
+    angle: 90,
+    shape: 'diamond',
+  },
+};
+
+const liquidMetalBackdropPreset: ImageShaderPreset<LiquidMetalParams> = {
+  name: 'Backdrop',
+  params: {
+    ...defaultObjectSizing,
+    speed: 1,
+    frame: 0,
+    scale: 1.5,
+    colorBack: '#AAAAAC',
+    colorTint: '#ffffff',
+    softness: 0.05,
+    repetition: 1.5,
+    shiftRed: 0.3,
+    shiftBlue: 0.3,
+    distortion: 0.1,
+    contour: 0.4,
+    shape: 'none',
+    angle: 90,
+    worldWidth: 0,
+    worldHeight: 0,
+  },
+};
+
+const liquidMetalStripesPreset: ImageShaderPreset<LiquidMetalParams> = {
+  name: 'Stripes',
+  params: {
+    ...defaultObjectSizing,
+    speed: 1,
+    frame: 0,
+    scale: 0.6,
+    colorBack: '#000000',
+    colorTint: '#2c5d72',
+    softness: 0.8,
+    repetition: 6,
+    shiftRed: 1,
+    shiftBlue: -1,
+    distortion: 0.4,
+    contour: 0.4,
+    shape: 'circle',
+    angle: 0,
+  },
+};
+
+export const liquidMetalPresets = [
+  liquidMetalDefaultPreset,
+  liquidMetalNoirPreset,
+  liquidMetalBackdropPreset,
+  liquidMetalStripesPreset,
+] satisfies ImageShaderPreset<LiquidMetalParams>[];
+
+const liquidMetalPropNames = shaderComponentPropNames(liquidMetalDefaultPreset.params, ['image', 'suspendWhenProcessingImage']);
+
+export const LiquidMetal = defineComponent({
+  name: 'LiquidMetal',
+  inheritAttrs: false,
+  props: liquidMetalPropNames,
+  setup(rawProps, { attrs }) {
+    const props = rawProps as unknown as LiquidMetalProps;
+    const processedImage = useProcessedImage(
+      () => toImageUrl(props.image),
+      'liquid metal',
+      async (imageUrl) => (await toProcessedLiquidMetal(imageUrl)).pngBlob
+    );
+
+    return () => {
+      const {
+        colorBack = liquidMetalDefaultPreset.params.colorBack,
+        colorTint = liquidMetalDefaultPreset.params.colorTint,
+        speed = liquidMetalDefaultPreset.params.speed,
+        frame = liquidMetalDefaultPreset.params.frame,
+        image = '',
+        contour = liquidMetalDefaultPreset.params.contour,
+        distortion = liquidMetalDefaultPreset.params.distortion,
+        softness = liquidMetalDefaultPreset.params.softness,
+        repetition = liquidMetalDefaultPreset.params.repetition,
+        shiftRed = liquidMetalDefaultPreset.params.shiftRed,
+        shiftBlue = liquidMetalDefaultPreset.params.shiftBlue,
+        angle = liquidMetalDefaultPreset.params.angle,
+        shape = liquidMetalDefaultPreset.params.shape,
+        suspendWhenProcessingImage: _suspendWhenProcessingImage = false,
+        fit = liquidMetalDefaultPreset.params.fit,
+        scale = liquidMetalDefaultPreset.params.scale,
+        rotation = liquidMetalDefaultPreset.params.rotation,
+        originX = liquidMetalDefaultPreset.params.originX,
+        originY = liquidMetalDefaultPreset.params.originY,
+        offsetX = liquidMetalDefaultPreset.params.offsetX,
+        offsetY = liquidMetalDefaultPreset.params.offsetY,
+        worldWidth = liquidMetalDefaultPreset.params.worldWidth,
+        worldHeight = liquidMetalDefaultPreset.params.worldHeight,
+        ...shaderProps
+      } = props;
+
+      const uniforms = {
+        u_colorBack: getShaderColorFromString(colorBack),
+        u_colorTint: getShaderColorFromString(colorTint),
+        u_image: processedImage.value,
+        u_contour: contour,
+        u_distortion: distortion,
+        u_softness: softness,
+        u_repetition: repetition,
+        u_shiftRed: shiftRed,
+        u_shiftBlue: shiftBlue,
+        u_angle: angle,
+        u_isImage: Boolean(image),
+        u_shape: LiquidMetalShapes[shape],
+        u_fit: ShaderFitOptions[fit],
+        u_scale: scale,
+        u_rotation: rotation,
+        u_offsetX: offsetX,
+        u_offsetY: offsetY,
+        u_originX: originX,
+        u_originY: originY,
+        u_worldWidth: worldWidth,
+        u_worldHeight: worldHeight,
+      } satisfies LiquidMetalUniforms;
+
+      return h(ShaderMount, {
+        ...attrs,
+        ...shaderProps,
+        speed,
+        frame,
+        fragmentShader: liquidMetalFragmentShader,
+        mipmaps: ['u_image'],
+        uniforms,
+      });
+    };
+  },
+});
+
+export interface HalftoneDotsProps extends ShaderComponentProps, HalftoneDotsParams {}
+
+const halftoneDotsDefaultPreset: ImageShaderPreset<HalftoneDotsParams> = {
+  name: 'Default',
+  params: {
+    ...defaultObjectSizing,
+    fit: 'cover',
+    speed: 0,
+    frame: 0,
+    colorBack: '#f2f1e8',
+    colorFront: '#2b2b2b',
+    size: 0.5,
+    radius: 1.25,
+    contrast: 0.4,
+    originalColors: false,
+    inverted: false,
+    grainMixer: 0.2,
+    grainOverlay: 0.2,
+    grainSize: 0.5,
+    grid: 'hex',
+    type: 'gooey',
+  },
+};
+
+const halftoneDotsLedPreset: ImageShaderPreset<HalftoneDotsParams> = {
+  name: 'LED screen',
+  params: {
+    ...defaultObjectSizing,
+    fit: 'cover',
+    speed: 0,
+    frame: 0,
+    colorBack: '#000000',
+    colorFront: '#29ff7b',
+    size: 0.5,
+    radius: 1.5,
+    contrast: 0.3,
+    originalColors: false,
+    inverted: false,
+    grainMixer: 0,
+    grainOverlay: 0,
+    grainSize: 0.5,
+    grid: 'square',
+    type: 'soft',
+  },
+};
+
+const halftoneDotsNetPreset: ImageShaderPreset<HalftoneDotsParams> = {
+  name: 'Mosaic',
+  params: {
+    ...defaultObjectSizing,
+    fit: 'cover',
+    speed: 0,
+    frame: 0,
+    colorBack: '#000000',
+    colorFront: '#b2aeae',
+    size: 0.6,
+    radius: 2,
+    contrast: 0.01,
+    originalColors: true,
+    inverted: false,
+    grainMixer: 0,
+    grainOverlay: 0,
+    grainSize: 0.5,
+    grid: 'hex',
+    type: 'classic',
+  },
+};
+
+const halftoneDotsRoundAndSquarePreset: ImageShaderPreset<HalftoneDotsParams> = {
+  name: 'Round and square',
+  params: {
+    ...defaultObjectSizing,
+    fit: 'cover',
+    speed: 0,
+    frame: 0,
+    colorBack: '#141414',
+    colorFront: '#ff8000',
+    size: 0.8,
+    radius: 1,
+    contrast: 1,
+    originalColors: false,
+    inverted: true,
+    grainMixer: 0.05,
+    grainOverlay: 0.3,
+    grainSize: 0.5,
+    grid: 'square',
+    type: 'holes',
+  },
+};
+
+export const halftoneDotsPresets = [
+  halftoneDotsDefaultPreset,
+  halftoneDotsLedPreset,
+  halftoneDotsNetPreset,
+  halftoneDotsRoundAndSquarePreset,
+] satisfies ImageShaderPreset<HalftoneDotsParams>[];
+
+export const HalftoneDots = createShaderComponent<HalftoneDotsProps>(
+  'HalftoneDots',
+  shaderComponentPropNames(halftoneDotsDefaultPreset.params),
+  ({
+    speed = halftoneDotsDefaultPreset.params.speed,
+    frame = halftoneDotsDefaultPreset.params.frame,
+    colorFront = halftoneDotsDefaultPreset.params.colorFront,
+    colorBack = halftoneDotsDefaultPreset.params.colorBack,
+    image = '',
+    size = halftoneDotsDefaultPreset.params.size,
+    radius = halftoneDotsDefaultPreset.params.radius,
+    contrast = halftoneDotsDefaultPreset.params.contrast,
+    originalColors = halftoneDotsDefaultPreset.params.originalColors,
+    inverted = halftoneDotsDefaultPreset.params.inverted,
+    grainMixer = halftoneDotsDefaultPreset.params.grainMixer,
+    grainOverlay = halftoneDotsDefaultPreset.params.grainOverlay,
+    grainSize = halftoneDotsDefaultPreset.params.grainSize,
+    grid = halftoneDotsDefaultPreset.params.grid,
+    type = halftoneDotsDefaultPreset.params.type,
+    fit = halftoneDotsDefaultPreset.params.fit,
+    scale = halftoneDotsDefaultPreset.params.scale,
+    rotation = halftoneDotsDefaultPreset.params.rotation,
+    originX = halftoneDotsDefaultPreset.params.originX,
+    originY = halftoneDotsDefaultPreset.params.originY,
+    offsetX = halftoneDotsDefaultPreset.params.offsetX,
+    offsetY = halftoneDotsDefaultPreset.params.offsetY,
+    worldWidth = halftoneDotsDefaultPreset.params.worldWidth,
+    worldHeight = halftoneDotsDefaultPreset.params.worldHeight,
+    ...props
+  }: HalftoneDotsProps) => {
+    const uniforms = {
+      u_image: image,
+      u_colorFront: getShaderColorFromString(colorFront),
+      u_colorBack: getShaderColorFromString(colorBack),
+      u_size: size,
+      u_radius: radius,
+      u_contrast: contrast,
+      u_originalColors: originalColors,
+      u_inverted: inverted,
+      u_grainMixer: grainMixer,
+      u_grainOverlay: grainOverlay,
+      u_grainSize: grainSize,
+      u_grid: HalftoneDotsGrids[grid],
+      u_type: HalftoneDotsTypes[type],
+      u_fit: ShaderFitOptions[fit],
+      u_rotation: rotation,
+      u_scale: scale,
+      u_offsetX: offsetX,
+      u_offsetY: offsetY,
+      u_originX: originX,
+      u_originY: originY,
+      u_worldWidth: worldWidth,
+      u_worldHeight: worldHeight,
+    } satisfies HalftoneDotsUniforms;
+
+    return {
+      ...props,
+      speed,
+      frame,
+      fragmentShader: halftoneDotsFragmentShader,
+      uniforms,
+    };
+  }
+);
+
+export interface HalftoneCmykProps extends ShaderComponentProps, HalftoneCmykParams {}
+
+const halftoneCmykDefaultPreset: ImageShaderPreset<HalftoneCmykParams> = {
+  name: 'Default',
+  params: {
+    ...defaultObjectSizing,
+    scale: 1,
+    fit: 'cover',
+    speed: 0,
+    frame: 0,
+    colorBack: '#fbfaf5',
+    colorC: '#00b4ff',
+    colorM: '#fc519f',
+    colorY: '#ffd800',
+    colorK: '#231f20',
+    size: 0.2,
+    contrast: 1,
+    softness: 1,
+    grainSize: 0.5,
+    grainMixer: 0,
+    grainOverlay: 0,
+    gridNoise: 0.2,
+    floodC: 0.15,
+    floodM: 0,
+    floodY: 0,
+    floodK: 0,
+    gainC: 0.3,
+    gainM: 0,
+    gainY: 0.2,
+    gainK: 0,
+    type: 'ink',
+  },
+};
+
+const halftoneCmykDropsPreset: ImageShaderPreset<HalftoneCmykParams> = {
+  name: 'Drops',
+  params: {
+    ...defaultObjectSizing,
+    scale: 1,
+    fit: 'cover',
+    speed: 0,
+    frame: 0,
+    colorBack: '#eeefd7',
+    colorC: '#00b2ff',
+    colorM: '#fc4f4f',
+    colorY: '#ffd900',
+    colorK: '#231f20',
+    size: 0.88,
+    contrast: 1.15,
+    softness: 0,
+    grainSize: 0.01,
+    grainMixer: 0.05,
+    grainOverlay: 0.25,
+    gridNoise: 0.5,
+    floodC: 0.15,
+    floodM: 0,
+    floodY: 0,
+    floodK: 0,
+    gainC: 1,
+    gainM: 0.44,
+    gainY: -1,
+    gainK: 0,
+    type: 'ink',
+  },
+};
+
+const halftoneCmykNewspaperPreset: ImageShaderPreset<HalftoneCmykParams> = {
+  name: 'Newspaper',
+  params: {
+    ...defaultObjectSizing,
+    scale: 1,
+    fit: 'cover',
+    speed: 0,
+    frame: 0,
+    colorBack: '#f2f1e8',
+    colorC: '#7a7a75',
+    colorM: '#7a7a75',
+    colorY: '#7a7a75',
+    colorK: '#231f20',
+    size: 0.01,
+    contrast: 2,
+    softness: 0.2,
+    grainSize: 0,
+    grainMixer: 0,
+    grainOverlay: 0.2,
+    gridNoise: 0.6,
+    floodC: 0,
+    floodM: 0,
+    floodY: 0,
+    floodK: 0.1,
+    gainC: -0.17,
+    gainM: -0.45,
+    gainY: -0.45,
+    gainK: 0,
+    type: 'dots',
+  },
+};
+
+const halftoneCmykVintagePreset: ImageShaderPreset<HalftoneCmykParams> = {
+  name: 'Vintage',
+  params: {
+    ...defaultObjectSizing,
+    scale: 1,
+    fit: 'cover',
+    speed: 0,
+    frame: 0,
+    colorBack: '#fffaf0',
+    colorC: '#59afc5',
+    colorM: '#d8697c',
+    colorY: '#fad85c',
+    colorK: '#2d2824',
+    size: 0.2,
+    contrast: 1.25,
+    softness: 0.4,
+    grainSize: 0.5,
+    grainMixer: 0.15,
+    grainOverlay: 0.1,
+    gridNoise: 0.45,
+    floodC: 0.15,
+    floodM: 0,
+    floodY: 0,
+    floodK: 0,
+    gainC: 0.3,
+    gainM: 0,
+    gainY: 0.2,
+    gainK: 0,
+    type: 'sharp',
+  },
+};
+
+export const halftoneCmykPresets = [
+  halftoneCmykDefaultPreset,
+  halftoneCmykDropsPreset,
+  halftoneCmykNewspaperPreset,
+  halftoneCmykVintagePreset,
+] satisfies ImageShaderPreset<HalftoneCmykParams>[];
+
+export const HalftoneCmyk = createShaderComponent<HalftoneCmykProps>(
+  'HalftoneCmyk',
+  shaderComponentPropNames(halftoneCmykDefaultPreset.params),
+  ({
+    speed = halftoneCmykDefaultPreset.params.speed,
+    frame = halftoneCmykDefaultPreset.params.frame,
+    colorBack = halftoneCmykDefaultPreset.params.colorBack,
+    colorC = halftoneCmykDefaultPreset.params.colorC,
+    colorM = halftoneCmykDefaultPreset.params.colorM,
+    colorY = halftoneCmykDefaultPreset.params.colorY,
+    colorK = halftoneCmykDefaultPreset.params.colorK,
+    image = '',
+    size = halftoneCmykDefaultPreset.params.size,
+    contrast = halftoneCmykDefaultPreset.params.contrast,
+    softness = halftoneCmykDefaultPreset.params.softness,
+    grainSize = halftoneCmykDefaultPreset.params.grainSize,
+    grainMixer = halftoneCmykDefaultPreset.params.grainMixer,
+    grainOverlay = halftoneCmykDefaultPreset.params.grainOverlay,
+    gridNoise = halftoneCmykDefaultPreset.params.gridNoise,
+    floodC = halftoneCmykDefaultPreset.params.floodC,
+    floodM = halftoneCmykDefaultPreset.params.floodM,
+    floodY = halftoneCmykDefaultPreset.params.floodY,
+    floodK = halftoneCmykDefaultPreset.params.floodK,
+    gainC = halftoneCmykDefaultPreset.params.gainC,
+    gainM = halftoneCmykDefaultPreset.params.gainM,
+    gainY = halftoneCmykDefaultPreset.params.gainY,
+    gainK = halftoneCmykDefaultPreset.params.gainK,
+    type = halftoneCmykDefaultPreset.params.type,
+    fit = halftoneCmykDefaultPreset.params.fit,
+    scale = halftoneCmykDefaultPreset.params.scale,
+    rotation = halftoneCmykDefaultPreset.params.rotation,
+    originX = halftoneCmykDefaultPreset.params.originX,
+    originY = halftoneCmykDefaultPreset.params.originY,
+    offsetX = halftoneCmykDefaultPreset.params.offsetX,
+    offsetY = halftoneCmykDefaultPreset.params.offsetY,
+    worldWidth = halftoneCmykDefaultPreset.params.worldWidth,
+    worldHeight = halftoneCmykDefaultPreset.params.worldHeight,
+    ...props
+  }: HalftoneCmykProps) => {
+    const uniforms = {
+      u_image: image,
+      u_noiseTexture: getShaderNoiseTexture(),
+      u_colorBack: getShaderColorFromString(colorBack),
+      u_colorC: getShaderColorFromString(colorC),
+      u_colorM: getShaderColorFromString(colorM),
+      u_colorY: getShaderColorFromString(colorY),
+      u_colorK: getShaderColorFromString(colorK),
+      u_size: size,
+      u_contrast: contrast,
+      u_softness: softness,
+      u_grainSize: grainSize,
+      u_grainMixer: grainMixer,
+      u_grainOverlay: grainOverlay,
+      u_gridNoise: gridNoise,
+      u_floodC: floodC,
+      u_floodM: floodM,
+      u_floodY: floodY,
+      u_floodK: floodK,
+      u_gainC: gainC,
+      u_gainM: gainM,
+      u_gainY: gainY,
+      u_gainK: gainK,
+      u_type: HalftoneCmykTypes[type],
+      u_fit: ShaderFitOptions[fit],
+      u_rotation: rotation,
+      u_scale: scale,
+      u_offsetX: offsetX,
+      u_offsetY: offsetY,
+      u_originX: originX,
+      u_originY: originY,
+      u_worldWidth: worldWidth,
+      u_worldHeight: worldHeight,
+    } satisfies HalftoneCmykUniforms;
+
+    return {
+      ...props,
+      speed,
+      frame,
+      fragmentShader: halftoneCmykFragmentShader,
+      uniforms,
+    };
+  }
+);

--- a/packages/shaders-vue/src/shaders-static.ts
+++ b/packages/shaders-vue/src/shaders-static.ts
@@ -1,0 +1,902 @@
+import {
+  DitheringShapes,
+  DitheringTypes,
+  DotGridShapes,
+  ShaderFitOptions,
+  colorPanelsFragmentShader,
+  defaultObjectSizing,
+  defaultPatternSizing,
+  ditheringFragmentShader,
+  dotGridFragmentShader,
+  getShaderColorFromString,
+  staticMeshGradientFragmentShader,
+  staticRadialGradientFragmentShader,
+  wavesFragmentShader,
+  type ColorPanelsParams,
+  type ColorPanelsUniforms,
+  type DitheringParams,
+  type DitheringUniforms,
+  type DotGridParams,
+  type DotGridUniforms,
+  type ShaderPreset,
+  type StaticMeshGradientParams,
+  type StaticMeshGradientUniforms,
+  type StaticRadialGradientParams,
+  type StaticRadialGradientUniforms,
+  type WavesParams,
+  type WavesUniforms,
+} from '@paper-design/shaders';
+import { createShaderComponent, shaderComponentPropNames } from './create-shader-component.js';
+import type { ShaderComponentProps } from './shader-mount.js';
+
+export interface ColorPanelsProps extends ShaderComponentProps, ColorPanelsParams {}
+
+const colorPanelsDefaultPreset: ShaderPreset<ColorPanelsParams> = {
+  name: 'Default',
+  params: {
+    ...defaultObjectSizing,
+    speed: 0.5,
+    frame: 0,
+    colors: ['#ff9d00', '#fd4f30', '#809bff', '#6d2eff', '#333aff', '#f15cff', '#ffd557'],
+    colorBack: '#000000',
+    angle1: 0,
+    angle2: 0,
+    length: 1.1,
+    edges: false,
+    blur: 0,
+    fadeIn: 1,
+    fadeOut: 0.3,
+    gradient: 0,
+    density: 3,
+    scale: 0.8,
+  },
+};
+
+const colorPanelsGlassPreset: ShaderPreset<ColorPanelsParams> = {
+  name: 'Glass',
+  params: {
+    ...defaultObjectSizing,
+    rotation: 112,
+    speed: 1,
+    frame: 0,
+    colors: ['#00cfff', '#ff2d55', '#34c759', '#af52de'],
+    colorBack: '#ffffff00',
+    angle1: 0.3,
+    angle2: 0.3,
+    length: 1,
+    edges: true,
+    blur: 0.25,
+    fadeIn: 0.85,
+    fadeOut: 0.3,
+    gradient: 0,
+    density: 1.6,
+  },
+};
+
+const colorPanelsGradientPreset: ShaderPreset<ColorPanelsParams> = {
+  name: 'Gradient',
+  params: {
+    ...defaultObjectSizing,
+    speed: 0.5,
+    frame: 0,
+    colors: ['#f2ff00', '#00000000', '#00000000', '#5a0283', '#005eff'],
+    colorBack: '#8ffff2',
+    angle1: 0.4,
+    angle2: 0.4,
+    length: 3,
+    edges: false,
+    blur: 0.5,
+    fadeIn: 1,
+    fadeOut: 0.39,
+    gradient: 0.78,
+    density: 1.65,
+    scale: 1.72,
+    rotation: 270,
+    offsetX: 0.18,
+  },
+};
+
+const colorPanelsOpeningPreset: ShaderPreset<ColorPanelsParams> = {
+  name: 'Opening',
+  params: {
+    ...defaultObjectSizing,
+    speed: 2,
+    frame: 0,
+    colors: ['#00ffff'],
+    colorBack: '#570044',
+    angle1: -1,
+    angle2: -1,
+    length: 0.52,
+    edges: false,
+    blur: 0,
+    fadeIn: 0,
+    fadeOut: 1,
+    gradient: 0,
+    density: 2.21,
+    scale: 2.32,
+    rotation: 360,
+    offsetX: -0.3,
+    offsetY: 0.6,
+  },
+};
+
+export const colorPanelsPresets = [
+  colorPanelsDefaultPreset,
+  colorPanelsGlassPreset,
+  colorPanelsGradientPreset,
+  colorPanelsOpeningPreset,
+] satisfies ShaderPreset<ColorPanelsParams>[];
+
+export const ColorPanels = createShaderComponent<ColorPanelsProps>(
+  'ColorPanels',
+  shaderComponentPropNames(colorPanelsDefaultPreset.params),
+  ({
+    speed = colorPanelsDefaultPreset.params.speed,
+    frame = colorPanelsDefaultPreset.params.frame,
+    colors = colorPanelsDefaultPreset.params.colors,
+    colorBack = colorPanelsDefaultPreset.params.colorBack,
+    angle1 = colorPanelsDefaultPreset.params.angle1,
+    angle2 = colorPanelsDefaultPreset.params.angle2,
+    length = colorPanelsDefaultPreset.params.length,
+    edges = colorPanelsDefaultPreset.params.edges,
+    blur = colorPanelsDefaultPreset.params.blur,
+    fadeIn = colorPanelsDefaultPreset.params.fadeIn,
+    fadeOut = colorPanelsDefaultPreset.params.fadeOut,
+    density = colorPanelsDefaultPreset.params.density,
+    gradient = colorPanelsDefaultPreset.params.gradient,
+    fit = colorPanelsDefaultPreset.params.fit,
+    scale = colorPanelsDefaultPreset.params.scale,
+    rotation = colorPanelsDefaultPreset.params.rotation,
+    originX = colorPanelsDefaultPreset.params.originX,
+    originY = colorPanelsDefaultPreset.params.originY,
+    offsetX = colorPanelsDefaultPreset.params.offsetX,
+    offsetY = colorPanelsDefaultPreset.params.offsetY,
+    worldWidth = colorPanelsDefaultPreset.params.worldWidth,
+    worldHeight = colorPanelsDefaultPreset.params.worldHeight,
+    ...props
+  }: ColorPanelsProps) => {
+    const uniforms = {
+      u_colors: colors.map(getShaderColorFromString),
+      u_colorsCount: colors.length,
+      u_colorBack: getShaderColorFromString(colorBack),
+      u_angle1: angle1,
+      u_angle2: angle2,
+      u_length: length,
+      u_edges: edges,
+      u_blur: blur,
+      u_fadeIn: fadeIn,
+      u_fadeOut: fadeOut,
+      u_density: density,
+      u_gradient: gradient,
+      u_fit: ShaderFitOptions[fit],
+      u_scale: scale,
+      u_rotation: rotation,
+      u_offsetX: offsetX,
+      u_offsetY: offsetY,
+      u_originX: originX,
+      u_originY: originY,
+      u_worldWidth: worldWidth,
+      u_worldHeight: worldHeight,
+    } satisfies ColorPanelsUniforms;
+
+    return {
+      ...props,
+      speed,
+      frame,
+      fragmentShader: colorPanelsFragmentShader,
+      uniforms,
+    };
+  }
+);
+
+export interface DitheringProps extends ShaderComponentProps, DitheringParams {
+  pxSize?: number;
+}
+
+const ditheringDefaultPreset: ShaderPreset<DitheringParams> = {
+  name: 'Default',
+  params: {
+    ...defaultPatternSizing,
+    speed: 1,
+    frame: 0,
+    scale: 0.6,
+    colorBack: '#000000',
+    colorFront: '#00b2ff',
+    shape: 'sphere',
+    type: '4x4',
+    size: 2,
+  },
+};
+
+const ditheringSinePreset: ShaderPreset<DitheringParams> = {
+  name: 'Sine Wave',
+  params: {
+    ...defaultPatternSizing,
+    speed: 1,
+    frame: 0,
+    colorBack: '#730d54',
+    colorFront: '#00becc',
+    shape: 'wave',
+    type: '4x4',
+    size: 11,
+    scale: 1.2,
+  },
+};
+
+const ditheringBugsPreset: ShaderPreset<DitheringParams> = {
+  name: 'Bugs',
+  params: {
+    ...defaultPatternSizing,
+    speed: 1,
+    frame: 0,
+    colorBack: '#000000',
+    colorFront: '#008000',
+    shape: 'dots',
+    type: 'random',
+    size: 9,
+  },
+};
+
+const ditheringRipplePreset: ShaderPreset<DitheringParams> = {
+  name: 'Ripple',
+  params: {
+    ...defaultObjectSizing,
+    speed: 1,
+    frame: 0,
+    colorBack: '#603520',
+    colorFront: '#c67953',
+    shape: 'ripple',
+    type: '2x2',
+    size: 3,
+  },
+};
+
+const ditheringSwirlPreset: ShaderPreset<DitheringParams> = {
+  name: 'Swirl',
+  params: {
+    ...defaultObjectSizing,
+    speed: 1,
+    frame: 0,
+    colorBack: '#00000000',
+    colorFront: '#47a8e1',
+    shape: 'swirl',
+    type: '8x8',
+    size: 2,
+  },
+};
+
+const ditheringWarpPreset: ShaderPreset<DitheringParams> = {
+  name: 'Warp',
+  params: {
+    ...defaultObjectSizing,
+    speed: 1,
+    frame: 0,
+    colorBack: '#301c2a',
+    colorFront: '#56ae6c',
+    shape: 'warp',
+    type: '4x4',
+    size: 2.5,
+  },
+};
+
+export const ditheringPresets = [
+  ditheringDefaultPreset,
+  ditheringWarpPreset,
+  ditheringSinePreset,
+  ditheringRipplePreset,
+  ditheringBugsPreset,
+  ditheringSwirlPreset,
+] satisfies ShaderPreset<DitheringParams>[];
+
+export const Dithering = createShaderComponent<DitheringProps>(
+  'Dithering',
+  shaderComponentPropNames(ditheringDefaultPreset.params, ['pxSize']),
+  ({
+    speed = ditheringDefaultPreset.params.speed,
+    frame = ditheringDefaultPreset.params.frame,
+    colorBack = ditheringDefaultPreset.params.colorBack,
+    colorFront = ditheringDefaultPreset.params.colorFront,
+    shape = ditheringDefaultPreset.params.shape,
+    type = ditheringDefaultPreset.params.type,
+    pxSize,
+    size = pxSize === undefined ? ditheringDefaultPreset.params.size : pxSize,
+    fit = ditheringDefaultPreset.params.fit,
+    scale = ditheringDefaultPreset.params.scale,
+    rotation = ditheringDefaultPreset.params.rotation,
+    originX = ditheringDefaultPreset.params.originX,
+    originY = ditheringDefaultPreset.params.originY,
+    offsetX = ditheringDefaultPreset.params.offsetX,
+    offsetY = ditheringDefaultPreset.params.offsetY,
+    worldWidth = ditheringDefaultPreset.params.worldWidth,
+    worldHeight = ditheringDefaultPreset.params.worldHeight,
+    ...props
+  }: DitheringProps) => {
+    const uniforms = {
+      u_colorBack: getShaderColorFromString(colorBack),
+      u_colorFront: getShaderColorFromString(colorFront),
+      u_shape: DitheringShapes[shape],
+      u_type: DitheringTypes[type],
+      u_pxSize: size,
+      u_fit: ShaderFitOptions[fit],
+      u_scale: scale,
+      u_rotation: rotation,
+      u_offsetX: offsetX,
+      u_offsetY: offsetY,
+      u_originX: originX,
+      u_originY: originY,
+      u_worldWidth: worldWidth,
+      u_worldHeight: worldHeight,
+    } satisfies DitheringUniforms;
+
+    return {
+      ...props,
+      speed,
+      frame,
+      fragmentShader: ditheringFragmentShader,
+      uniforms,
+    };
+  }
+);
+
+export interface DotGridProps extends ShaderComponentProps, DotGridParams {}
+
+const dotGridDefaultPreset: ShaderPreset<DotGridParams> = {
+  name: 'Default',
+  params: {
+    ...defaultPatternSizing,
+    colorBack: '#000000',
+    colorFill: '#ffffff',
+    colorStroke: '#ffaa00',
+    size: 2,
+    gapX: 32,
+    gapY: 32,
+    strokeWidth: 0,
+    sizeRange: 0,
+    opacityRange: 0,
+    shape: 'circle',
+  },
+};
+
+const dotGridTrianglesPreset: ShaderPreset<DotGridParams> = {
+  name: 'Triangles',
+  params: {
+    ...defaultPatternSizing,
+    colorBack: '#ffffff',
+    colorFill: '#ffffff',
+    colorStroke: '#808080',
+    size: 5,
+    gapX: 32,
+    gapY: 32,
+    strokeWidth: 1,
+    sizeRange: 0,
+    opacityRange: 0,
+    shape: 'triangle',
+  },
+};
+
+const dotGridTreeLinePreset: ShaderPreset<DotGridParams> = {
+  name: 'Tree line',
+  params: {
+    ...defaultPatternSizing,
+    colorBack: '#f4fce7',
+    colorFill: '#052e19',
+    colorStroke: '#000000',
+    size: 8,
+    gapX: 20,
+    gapY: 90,
+    strokeWidth: 0,
+    sizeRange: 1,
+    opacityRange: 0.6,
+    shape: 'circle',
+  },
+};
+
+const dotGridWallpaperPreset: ShaderPreset<DotGridParams> = {
+  name: 'Wallpaper',
+  params: {
+    ...defaultPatternSizing,
+    colorBack: '#204030',
+    colorFill: '#000000',
+    colorStroke: '#bd955b',
+    size: 9,
+    gapX: 32,
+    gapY: 32,
+    strokeWidth: 1,
+    sizeRange: 0,
+    opacityRange: 0,
+    shape: 'diamond',
+  },
+};
+
+export const dotGridPresets = [
+  dotGridDefaultPreset,
+  dotGridTrianglesPreset,
+  dotGridTreeLinePreset,
+  dotGridWallpaperPreset,
+] satisfies ShaderPreset<DotGridParams>[];
+
+export const DotGrid = createShaderComponent<DotGridProps>(
+  'DotGrid',
+  shaderComponentPropNames(dotGridDefaultPreset.params),
+  ({
+    colorBack = dotGridDefaultPreset.params.colorBack,
+    colorFill = dotGridDefaultPreset.params.colorFill,
+    colorStroke = dotGridDefaultPreset.params.colorStroke,
+    size = dotGridDefaultPreset.params.size,
+    gapX = dotGridDefaultPreset.params.gapX,
+    gapY = dotGridDefaultPreset.params.gapY,
+    strokeWidth = dotGridDefaultPreset.params.strokeWidth,
+    sizeRange = dotGridDefaultPreset.params.sizeRange,
+    opacityRange = dotGridDefaultPreset.params.opacityRange,
+    shape = dotGridDefaultPreset.params.shape,
+    fit = dotGridDefaultPreset.params.fit,
+    scale = dotGridDefaultPreset.params.scale,
+    rotation = dotGridDefaultPreset.params.rotation,
+    originX = dotGridDefaultPreset.params.originX,
+    originY = dotGridDefaultPreset.params.originY,
+    offsetX = dotGridDefaultPreset.params.offsetX,
+    offsetY = dotGridDefaultPreset.params.offsetY,
+    worldWidth = dotGridDefaultPreset.params.worldWidth,
+    worldHeight = dotGridDefaultPreset.params.worldHeight,
+    maxPixelCount = 6016 * 3384,
+    ...props
+  }: DotGridProps) => {
+    const uniforms = {
+      u_colorBack: getShaderColorFromString(colorBack),
+      u_colorFill: getShaderColorFromString(colorFill),
+      u_colorStroke: getShaderColorFromString(colorStroke),
+      u_dotSize: size,
+      u_gapX: gapX,
+      u_gapY: gapY,
+      u_strokeWidth: strokeWidth,
+      u_sizeRange: sizeRange,
+      u_opacityRange: opacityRange,
+      u_shape: DotGridShapes[shape],
+      u_fit: ShaderFitOptions[fit],
+      u_scale: scale,
+      u_rotation: rotation,
+      u_offsetX: offsetX,
+      u_offsetY: offsetY,
+      u_originX: originX,
+      u_originY: originY,
+      u_worldWidth: worldWidth,
+      u_worldHeight: worldHeight,
+    } satisfies DotGridUniforms;
+
+    return {
+      ...props,
+      maxPixelCount,
+      fragmentShader: dotGridFragmentShader,
+      uniforms,
+    };
+  }
+);
+
+export interface StaticMeshGradientProps extends ShaderComponentProps, StaticMeshGradientParams {}
+
+const staticMeshGradientDefaultPreset: ShaderPreset<StaticMeshGradientParams> = {
+  name: 'Default',
+  params: {
+    ...defaultObjectSizing,
+    rotation: 270,
+    speed: 0,
+    frame: 0,
+    colors: ['#ffad0a', '#6200ff', '#e2a3ff', '#ff99fd'],
+    positions: 2,
+    waveX: 1,
+    waveXShift: 0.6,
+    waveY: 1,
+    waveYShift: 0.21,
+    mixing: 0.93,
+    grainMixer: 0,
+    grainOverlay: 0,
+  },
+};
+
+const staticMeshGradientSeaPreset: ShaderPreset<StaticMeshGradientParams> = {
+  name: 'Sea',
+  params: {
+    ...defaultObjectSizing,
+    speed: 0,
+    frame: 0,
+    colors: ['#013b65', '#03738c', '#a3d3ff', '#f2faef'],
+    positions: 0,
+    waveX: 0.53,
+    waveXShift: 0,
+    waveY: 0.95,
+    waveYShift: 0.64,
+    mixing: 0.5,
+    grainMixer: 0,
+    grainOverlay: 0,
+  },
+};
+
+const staticMeshGradientSixtiesPreset: ShaderPreset<StaticMeshGradientParams> = {
+  name: '1960s',
+  params: {
+    ...defaultObjectSizing,
+    speed: 0,
+    frame: 0,
+    colors: ['#000000', '#082400', '#b1aa91', '#8e8c15'],
+    positions: 42,
+    waveX: 0.45,
+    waveXShift: 0,
+    waveY: 1,
+    waveYShift: 0,
+    mixing: 0,
+    grainMixer: 0.37,
+    grainOverlay: 0.78,
+  },
+};
+
+const staticMeshGradientSunsetPreset: ShaderPreset<StaticMeshGradientParams> = {
+  name: 'Sunset',
+  params: {
+    ...defaultObjectSizing,
+    speed: 0,
+    frame: 0,
+    colors: ['#264653', '#9c2b2b', '#f4a261', '#ffffff'],
+    positions: 0,
+    waveX: 0.6,
+    waveXShift: 0.7,
+    waveY: 0.7,
+    waveYShift: 0.7,
+    mixing: 0.5,
+    grainMixer: 0,
+    grainOverlay: 0,
+  },
+};
+
+export const staticMeshGradientPresets = [
+  staticMeshGradientDefaultPreset,
+  staticMeshGradientSixtiesPreset,
+  staticMeshGradientSunsetPreset,
+  staticMeshGradientSeaPreset,
+] satisfies ShaderPreset<StaticMeshGradientParams>[];
+
+export const StaticMeshGradient = createShaderComponent<StaticMeshGradientProps>(
+  'StaticMeshGradient',
+  shaderComponentPropNames(staticMeshGradientDefaultPreset.params),
+  ({
+    speed = staticMeshGradientDefaultPreset.params.speed,
+    frame = staticMeshGradientDefaultPreset.params.frame,
+    colors = staticMeshGradientDefaultPreset.params.colors,
+    positions = staticMeshGradientDefaultPreset.params.positions,
+    waveX = staticMeshGradientDefaultPreset.params.waveX,
+    waveXShift = staticMeshGradientDefaultPreset.params.waveXShift,
+    waveY = staticMeshGradientDefaultPreset.params.waveY,
+    waveYShift = staticMeshGradientDefaultPreset.params.waveYShift,
+    mixing = staticMeshGradientDefaultPreset.params.mixing,
+    grainMixer = staticMeshGradientDefaultPreset.params.grainMixer,
+    grainOverlay = staticMeshGradientDefaultPreset.params.grainOverlay,
+    fit = staticMeshGradientDefaultPreset.params.fit,
+    rotation = staticMeshGradientDefaultPreset.params.rotation,
+    scale = staticMeshGradientDefaultPreset.params.scale,
+    originX = staticMeshGradientDefaultPreset.params.originX,
+    originY = staticMeshGradientDefaultPreset.params.originY,
+    offsetX = staticMeshGradientDefaultPreset.params.offsetX,
+    offsetY = staticMeshGradientDefaultPreset.params.offsetY,
+    worldWidth = staticMeshGradientDefaultPreset.params.worldWidth,
+    worldHeight = staticMeshGradientDefaultPreset.params.worldHeight,
+    ...props
+  }: StaticMeshGradientProps) => {
+    const uniforms = {
+      u_colors: colors.map(getShaderColorFromString),
+      u_colorsCount: colors.length,
+      u_positions: positions,
+      u_waveX: waveX,
+      u_waveXShift: waveXShift,
+      u_waveY: waveY,
+      u_waveYShift: waveYShift,
+      u_mixing: mixing,
+      u_grainMixer: grainMixer,
+      u_grainOverlay: grainOverlay,
+      u_fit: ShaderFitOptions[fit],
+      u_rotation: rotation,
+      u_scale: scale,
+      u_offsetX: offsetX,
+      u_offsetY: offsetY,
+      u_originX: originX,
+      u_originY: originY,
+      u_worldWidth: worldWidth,
+      u_worldHeight: worldHeight,
+    } satisfies StaticMeshGradientUniforms;
+
+    return {
+      ...props,
+      speed,
+      frame,
+      fragmentShader: staticMeshGradientFragmentShader,
+      uniforms,
+    };
+  }
+);
+
+export interface StaticRadialGradientProps extends ShaderComponentProps, StaticRadialGradientParams {}
+
+const staticRadialGradientDefaultPreset: ShaderPreset<StaticRadialGradientParams> = {
+  name: 'Default',
+  params: {
+    ...defaultObjectSizing,
+    scale: 1,
+    speed: 0,
+    frame: 0,
+    colorBack: '#000000',
+    colors: ['#00bbff', '#00ffe1', '#ffffff'],
+    radius: 0.8,
+    focalDistance: 0.99,
+    focalAngle: 0,
+    falloff: 0.24,
+    mixing: 0.5,
+    distortion: 0,
+    distortionShift: 0,
+    distortionFreq: 12,
+    grainMixer: 0,
+    grainOverlay: 0,
+  },
+};
+
+const staticRadialGradientCrossSectionPreset: ShaderPreset<StaticRadialGradientParams> = {
+  name: 'Cross Section',
+  params: {
+    ...defaultObjectSizing,
+    scale: 1,
+    speed: 0,
+    frame: 0,
+    colorBack: '#3d348b',
+    colors: ['#7678ed', '#f7b801', '#f18701', '#37a066'],
+    radius: 1,
+    focalDistance: 0,
+    focalAngle: 0,
+    falloff: 0,
+    mixing: 0,
+    distortion: 1,
+    distortionShift: 0,
+    distortionFreq: 12,
+    grainMixer: 0,
+    grainOverlay: 0,
+  },
+};
+
+const staticRadialGradientRadialPreset: ShaderPreset<StaticRadialGradientParams> = {
+  name: 'Radial',
+  params: {
+    ...defaultObjectSizing,
+    scale: 1,
+    speed: 0,
+    frame: 0,
+    colorBack: '#264653',
+    colors: ['#9c2b2b', '#f4a261', '#ffffff'],
+    radius: 1,
+    focalDistance: 0,
+    focalAngle: 0,
+    falloff: 0,
+    mixing: 1,
+    distortion: 0,
+    distortionShift: 0,
+    distortionFreq: 12,
+    grainMixer: 0,
+    grainOverlay: 0,
+  },
+};
+
+const staticRadialGradientLoFiPreset: ShaderPreset<StaticRadialGradientParams> = {
+  name: 'Lo-Fi',
+  params: {
+    ...defaultObjectSizing,
+    speed: 0,
+    frame: 0,
+    colorBack: '#2e1f27',
+    colors: ['#d72638', '#3f88c5', '#f49d37'],
+    radius: 1,
+    focalDistance: 0,
+    focalAngle: 0,
+    falloff: 0.9,
+    mixing: 0.7,
+    distortion: 0,
+    distortionShift: 0,
+    distortionFreq: 12,
+    grainMixer: 1,
+    grainOverlay: 0.5,
+  },
+};
+
+export const staticRadialGradientPresets = [
+  staticRadialGradientDefaultPreset,
+  staticRadialGradientLoFiPreset,
+  staticRadialGradientCrossSectionPreset,
+  staticRadialGradientRadialPreset,
+] satisfies ShaderPreset<StaticRadialGradientParams>[];
+
+export const StaticRadialGradient = createShaderComponent<StaticRadialGradientProps>(
+  'StaticRadialGradient',
+  shaderComponentPropNames(staticRadialGradientDefaultPreset.params),
+  ({
+    speed = staticRadialGradientDefaultPreset.params.speed,
+    frame = staticRadialGradientDefaultPreset.params.frame,
+    colorBack = staticRadialGradientDefaultPreset.params.colorBack,
+    colors = staticRadialGradientDefaultPreset.params.colors,
+    radius = staticRadialGradientDefaultPreset.params.radius,
+    focalDistance = staticRadialGradientDefaultPreset.params.focalDistance,
+    focalAngle = staticRadialGradientDefaultPreset.params.focalAngle,
+    falloff = staticRadialGradientDefaultPreset.params.falloff,
+    grainMixer = staticRadialGradientDefaultPreset.params.grainMixer,
+    mixing = staticRadialGradientDefaultPreset.params.mixing,
+    distortion = staticRadialGradientDefaultPreset.params.distortion,
+    distortionShift = staticRadialGradientDefaultPreset.params.distortionShift,
+    distortionFreq = staticRadialGradientDefaultPreset.params.distortionFreq,
+    grainOverlay = staticRadialGradientDefaultPreset.params.grainOverlay,
+    fit = staticRadialGradientDefaultPreset.params.fit,
+    rotation = staticRadialGradientDefaultPreset.params.rotation,
+    scale = staticRadialGradientDefaultPreset.params.scale,
+    originX = staticRadialGradientDefaultPreset.params.originX,
+    originY = staticRadialGradientDefaultPreset.params.originY,
+    offsetX = staticRadialGradientDefaultPreset.params.offsetX,
+    offsetY = staticRadialGradientDefaultPreset.params.offsetY,
+    worldWidth = staticRadialGradientDefaultPreset.params.worldWidth,
+    worldHeight = staticRadialGradientDefaultPreset.params.worldHeight,
+    ...props
+  }: StaticRadialGradientProps) => {
+    const uniforms = {
+      u_colorBack: getShaderColorFromString(colorBack),
+      u_colors: colors.map(getShaderColorFromString),
+      u_colorsCount: colors.length,
+      u_radius: radius,
+      u_focalDistance: focalDistance,
+      u_focalAngle: focalAngle,
+      u_falloff: falloff,
+      u_mixing: mixing,
+      u_distortion: distortion,
+      u_distortionShift: distortionShift,
+      u_distortionFreq: distortionFreq,
+      u_grainMixer: grainMixer,
+      u_grainOverlay: grainOverlay,
+      u_fit: ShaderFitOptions[fit],
+      u_rotation: rotation,
+      u_scale: scale,
+      u_offsetX: offsetX,
+      u_offsetY: offsetY,
+      u_originX: originX,
+      u_originY: originY,
+      u_worldWidth: worldWidth,
+      u_worldHeight: worldHeight,
+    } satisfies StaticRadialGradientUniforms;
+
+    return {
+      ...props,
+      speed,
+      frame,
+      fragmentShader: staticRadialGradientFragmentShader,
+      uniforms,
+    };
+  }
+);
+
+export interface WavesProps extends ShaderComponentProps, WavesParams {}
+
+const wavesDefaultPreset: ShaderPreset<WavesParams> = {
+  name: 'Default',
+  params: {
+    ...defaultPatternSizing,
+    scale: 0.6,
+    colorFront: '#ffbb00',
+    colorBack: '#000000',
+    shape: 0,
+    frequency: 0.5,
+    amplitude: 0.5,
+    spacing: 1.2,
+    proportion: 0.1,
+    softness: 0,
+  },
+};
+
+const wavesGroovyPreset: ShaderPreset<WavesParams> = {
+  name: 'Groovy',
+  params: {
+    ...defaultPatternSizing,
+    scale: 5,
+    rotation: 90,
+    colorFront: '#fcfcee',
+    colorBack: '#ff896b',
+    shape: 3,
+    frequency: 0.2,
+    amplitude: 0.25,
+    spacing: 1.17,
+    proportion: 0.57,
+    softness: 0,
+  },
+};
+
+const wavesTangledUpPreset: ShaderPreset<WavesParams> = {
+  name: 'Tangled up',
+  params: {
+    ...defaultPatternSizing,
+    scale: 0.5,
+    rotation: 0,
+    colorFront: '#133a41',
+    colorBack: '#c2d8b6',
+    shape: 2.07,
+    frequency: 0.44,
+    amplitude: 0.57,
+    spacing: 1.05,
+    proportion: 0.75,
+    softness: 0,
+  },
+};
+
+const wavesWaveRidePreset: ShaderPreset<WavesParams> = {
+  name: 'Ride the wave',
+  params: {
+    ...defaultPatternSizing,
+    scale: 1.7,
+    rotation: 0,
+    colorFront: '#fdffe6',
+    colorBack: '#1f1f1f',
+    shape: 2.25,
+    frequency: 0.2,
+    amplitude: 1,
+    spacing: 1.25,
+    proportion: 1,
+    softness: 0,
+  },
+};
+
+export const wavesPresets = [
+  wavesDefaultPreset,
+  wavesGroovyPreset,
+  wavesTangledUpPreset,
+  wavesWaveRidePreset,
+] satisfies ShaderPreset<WavesParams>[];
+
+export const Waves = createShaderComponent<WavesProps>(
+  'Waves',
+  shaderComponentPropNames(wavesDefaultPreset.params),
+  ({
+    colorFront = wavesDefaultPreset.params.colorFront,
+    colorBack = wavesDefaultPreset.params.colorBack,
+    shape = wavesDefaultPreset.params.shape,
+    frequency = wavesDefaultPreset.params.frequency,
+    amplitude = wavesDefaultPreset.params.amplitude,
+    spacing = wavesDefaultPreset.params.spacing,
+    proportion = wavesDefaultPreset.params.proportion,
+    softness = wavesDefaultPreset.params.softness,
+    fit = wavesDefaultPreset.params.fit,
+    scale = wavesDefaultPreset.params.scale,
+    rotation = wavesDefaultPreset.params.rotation,
+    offsetX = wavesDefaultPreset.params.offsetX,
+    offsetY = wavesDefaultPreset.params.offsetY,
+    originX = wavesDefaultPreset.params.originX,
+    originY = wavesDefaultPreset.params.originY,
+    worldWidth = wavesDefaultPreset.params.worldWidth,
+    worldHeight = wavesDefaultPreset.params.worldHeight,
+    maxPixelCount = 6016 * 3384,
+    ...props
+  }: WavesProps) => {
+    const uniforms = {
+      u_colorFront: getShaderColorFromString(colorFront),
+      u_colorBack: getShaderColorFromString(colorBack),
+      u_shape: shape,
+      u_frequency: frequency,
+      u_amplitude: amplitude,
+      u_spacing: spacing,
+      u_proportion: proportion,
+      u_softness: softness,
+      u_fit: ShaderFitOptions[fit],
+      u_scale: scale,
+      u_rotation: rotation,
+      u_offsetX: offsetX,
+      u_offsetY: offsetY,
+      u_originX: originX,
+      u_originY: originY,
+      u_worldWidth: worldWidth,
+      u_worldHeight: worldHeight,
+    } satisfies WavesUniforms;
+
+    return {
+      ...props,
+      maxPixelCount,
+      fragmentShader: wavesFragmentShader,
+      uniforms,
+    };
+  }
+);

--- a/packages/shaders-vue/tsconfig.build.json
+++ b/packages/shaders-vue/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "paths": {}
+  },
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+}

--- a/packages/shaders-vue/tsconfig.json
+++ b/packages/shaders-vue/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "target": "ESNext",
+    "declaration": true,
+    "outDir": "./dist",
+    "baseUrl": ".",
+    "module": "NodeNext",
+    "moduleDetection": "force",
+    "moduleResolution": "nodenext",
+    "verbatimModuleSyntax": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUnusedParameters": false,
+    "noUncheckedIndexedAccess": true,
+    "paths": {
+      "@paper-design/shaders": ["../shaders/src/index.ts"],
+      "@paper-design/shaders/*": ["../shaders/src/*"]
+    }
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/shaders/LICENSE
+++ b/packages/shaders/LICENSE
@@ -1,21 +1,164 @@
-MIT License
+# PolyForm Shield License 1.0.0
 
-Copyright (c) 2024 Lost Coast Labs, Inc. (Paper Design)
+<https://polyformproject.org/licenses/shield/1.0.0>
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+## Acceptance
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+In order to get any license under these terms, you must agree
+to them as both strict obligations and conditions to all
+your licenses.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+## Copyright License
+
+The licensor grants you a copyright license for the
+software to do everything you might do with the software
+that would otherwise infringe the licensor's copyright
+in it for any permitted purpose. However, you may
+only distribute the software according to [Distribution
+License](#distribution-license) and make changes or new works
+based on the software according to [Changes and New Works
+License](#changes-and-new-works-license).
+
+## Distribution License
+
+The licensor grants you an additional copyright license
+to distribute copies of the software. Your license
+to distribute covers distributing the software with
+changes and new works permitted by [Changes and New Works
+License](#changes-and-new-works-license).
+
+## Notices
+
+You must ensure that anyone who gets a copy of any part of
+the software from you also gets a copy of these terms or the
+URL for them above, as well as copies of any plain-text lines
+beginning with `Required Notice:` that the licensor provided
+with the software. For example:
+
+> Required Notice: Copyright Yoyodyne, Inc. (http://example.com)
+
+## Changes and New Works License
+
+The licensor grants you an additional copyright license to
+make changes and new works based on the software for any
+permitted purpose.
+
+## Patent License
+
+The licensor grants you a patent license for the software that
+covers patent claims the licensor can license, or becomes able
+to license, that you would infringe by using the software.
+
+## Noncompete
+
+Any purpose is a permitted purpose, except for providing any
+product that competes with the software or any product the
+licensor or any of its affiliates provides using the software.
+
+## Competition
+
+Goods and services compete even when they provide functionality
+through different kinds of interfaces or for different technical
+platforms. Applications can compete with services, libraries
+with plugins, frameworks with development tools, and so on,
+even if they're written in different programming languages
+or for different computer architectures. Goods and services
+compete even when provided free of charge. If you market a
+product as a practical substitute for the software or another
+product, it definitely competes.
+
+## New Products
+
+If you are using the software to provide a product that does
+not compete, but the licensor or any of its affiliates brings
+your product into competition by providing a new version of
+the software or another product using the software, you may
+continue using versions of the software available under these
+terms beforehand to provide your competing product, but not
+any later versions.
+
+## Discontinued Products
+
+You may begin using the software to compete with a product
+or service that the licensor or any of its affiliates has
+stopped providing, unless the licensor includes a plain-text
+line beginning with `Licensor Line of Business:` with the
+software that mentions that line of business. For example:
+
+> Licensor Line of Business: YoyodyneCMS Content Management
+> System (http://example.com/cms)
+
+## Sales of Business
+
+If the licensor or any of its affiliates sells a line of
+business developing the software or using the software
+to provide a product, the buyer can also enforce
+[Noncompete](#noncompete) for that product.
+
+## Fair Use
+
+You may have "fair use" rights for the software under the
+law. These terms do not limit them.
+
+## No Other Rights
+
+These terms do not allow you to sublicense or transfer any of
+your licenses to anyone else, or prevent the licensor from
+granting licenses to anyone else. These terms do not imply
+any other licenses.
+
+## Patent Defense
+
+If you make any written claim that the software infringes or
+contributes to infringement of any patent, your patent license
+for the software granted under these terms ends immediately. If
+your company makes such a claim, your patent license ends
+immediately for work on behalf of your company.
+
+## Violations
+
+The first time you are notified in writing that you have
+violated any of these terms, or done anything with the software
+not covered by your licenses, your licenses can nonetheless
+continue if you come into full compliance with these terms,
+and take practical steps to correct past violations, within
+32 days of receiving notice. Otherwise, all your licenses
+end immediately.
+
+## No Liability
+
+**_As far as the law allows, the software comes as is, without
+any warranty or condition, and the licensor will not be liable
+to you for any damages arising out of these terms or the use
+or nature of the software, under any kind of legal claim._**
+
+## Definitions
+
+The **licensor** is the individual or entity offering these
+terms, and the **software** is the software the licensor makes
+available under these terms.
+
+A **product** can be a good or service, or a combination
+of them.
+
+**You** refers to the individual or entity agreeing to these
+terms.
+
+**Your company** is any legal entity, sole proprietorship,
+or other kind of organization that you work for, plus all
+its affiliates.
+
+**Affiliates** means the other organizations than an
+organization has control over, is under the control of, or is
+under common control with.
+
+**Control** means ownership of substantially all the assets of
+an entity, or the power to direct its management and policies
+by vote, contract, or otherwise. Control can be direct or
+indirect.
+
+**Your licenses** are all the licenses granted to you for the
+software under these terms.
+
+**Use** means anything you do with the software requiring one
+of your licenses.

--- a/packages/shaders/src/shaders/spiral.ts
+++ b/packages/shaders/src/shaders/spiral.ts
@@ -29,7 +29,7 @@ import { simplexNoise, declarePI, colorBandingFix } from '../shader-utils.js';
  * - u_density (float): Spacing falloff simulating perspective, 0 = flat spiral (0 to 1)
  * - u_distortion (float): Power of shape distortion applied along the spiral (0 to 1)
  * - u_strokeWidth (float): Thickness of spiral curve (0 to 1)
- * - u_strokeTaper (float): How much stroke loses width away from center, 0 = full visibility (0 to 1)
+ * - u_strokeTaper (float): Stroke width taper along the spiral; positive = stroke fades out away from center, negative = stroke grows away from center, 0 = uniform width (-1 to 1)
  * - u_strokeCap (float): Extra stroke width at the center, no effect with strokeWidth = 0.5 (0 to 1)
  * - u_noise (float): Noise distortion applied over the canvas, no effect with noiseFrequency = 0 (0 to 1)
  * - u_noiseFrequency (float): Noise frequency, no effect with noise = 0 (0 to 1)
@@ -78,12 +78,13 @@ void main() {
   float stripe = fract(offset);
 
   float shape = 2. * abs(stripe - .5);
-  float width = 1. - clamp(u_strokeWidth, .005 * u_strokeTaper, 1.);
+  // float width = 1. - clamp(u_strokeWidth, .005 * u_strokeTaper, 1.);
+  float width = 1. - clamp(u_strokeWidth, 0., 1.);
 
 
   float wCap = mix(width, (1. - stripe) * (1. - step(.5, stripe)), (1. - clamp(l, 0., 1.)));
   width = mix(width, wCap, u_strokeCap);
-  width *= (1. - clamp(u_strokeTaper, 0., 1.) * l);
+  width *= (1. + clamp(u_strokeTaper, -1., 1.) * l);
 
   float fw = fwidth(offset);
   float fwMult = 4. - 3. * (smoothstep(.05, .4, 2. * u_strokeWidth) * smoothstep(.05, .4, 2. * (1. - u_strokeWidth)));


### PR DESCRIPTION
## Summary
- add a new `@paper-design/shaders-vue` workspace package for Vue and Nuxt consumers
- wire the Vue package into the root workspace and build script
- document usage and export the full shader surface through Vue wrappers

## Verification
- bun run build
- bun run --filter @paper-design/shaders-vue type-check