### PR TITLE
fix: pause animation when shader element leaves the viewport

### DIFF
--- a/packages/shaders/src/shader-mount.ts
+++ b/packages/shaders/src/shader-mount.ts
@@ -107,6 +107,8 @@ export class ShaderMount {
     this.setupResizeObserver();
     // Set up the visual viewport change listener to handle zoom changes (pinch zoom and classic browser zoom)
     visualViewport?.addEventListener('resize', this.handleVisualViewportChange);
+    // Set up the intersection observer to pause animation when the element is scrolled out of view
+    this.setupIntersectionObserver();
 
     // Set the animation speed after everything is ready to go
     this.setSpeed(speed);
@@ -172,6 +174,10 @@ export class ShaderMount {
   private parentDevicePixelHeight = 0;
   private devicePixelsSupported = false;
 
+  private intersectionObserver: IntersectionObserver | null = null;
+  /** Whether the parent element is currently intersecting the viewport */
+  private isInViewport = true;
+
   private resizeObserver: ResizeObserver | null = null;
   private setupResizeObserver = () => {
     this.resizeObserver = new ResizeObserver(([entry]) => {
@@ -192,6 +198,17 @@ export class ShaderMount {
     });
 
     this.resizeObserver.observe(this.parentElement);
+  };
+
+  private setupIntersectionObserver = () => {
+    if (typeof IntersectionObserver === 'undefined') return;
+
+    this.intersectionObserver = new IntersectionObserver(([entry]) => {
+      this.isInViewport = entry?.isIntersecting ?? true;
+      this.setCurrentSpeed(this.ownerDocument.hidden || !this.isInViewport ? 0 : this.speed);
+    });
+
+    this.intersectionObserver.observe(this.parentElement);
   };
 
   // Visual viewport resize handler, mainly used to react to browser zoom changes.
@@ -490,7 +507,7 @@ export class ShaderMount {
   public setSpeed = (newSpeed = 1): void => {
     // Set the new animation speed
     this.speed = newSpeed;
-    this.setCurrentSpeed(this.ownerDocument.hidden ? 0 : newSpeed);
+    this.setCurrentSpeed(this.ownerDocument.hidden || !this.isInViewport ? 0 : newSpeed);
   };
 
   private setCurrentSpeed = (newSpeed: number): void => {
@@ -532,7 +549,7 @@ export class ShaderMount {
   };
 
   private handleDocumentVisibilityChange = () => {
-    this.setCurrentSpeed(this.ownerDocument.hidden ? 0 : this.speed);
+    this.setCurrentSpeed(this.ownerDocument.hidden || !this.isInViewport ? 0 : this.speed);
   };
 
   /** Dispose of the shader mount, cleaning up all of the WebGL resources */
@@ -569,6 +586,11 @@ export class ShaderMount {
     if (this.resizeObserver) {
       this.resizeObserver.disconnect();
       this.resizeObserver = null;
+    }
+
+    if (this.intersectionObserver) {
+      this.intersectionObserver.disconnect();
+      this.intersectionObserver = null;
     }
 
     visualViewport?.removeEventListener('resize', this.handleVisualViewportChange);

--- a/packages/shaders/src/shader-mount.ts
+++ b/packages/shaders/src/shader-mount.ts
@@ -18,7 +18,7 @@ export class ShaderMount {
   private currentFrame = 0;
   /** The speed that we progress through animation time (multiplies by delta time every update). Allows negatives to play in reverse. If set to 0, rAF will stop entirely so static shaders have no recurring performance costs */
   private speed = 0;
-  /** Actual speed used that accounts for document visibility (we pause the shader if the tab is hidden) */
+  /** Actual speed used that accounts for visibility: we pause the shader if the tab is hidden or the element out of the viewport */
   private currentSpeed = 0;
   /** Uniforms that are provided by the user for the specific shader being mounted (not including uniforms that this Mount adds, like time and resolution) */
   private providedUniforms: ShaderMountUniforms;
@@ -207,7 +207,7 @@ export class ShaderMount {
 
     this.intersectionObserver = new view.IntersectionObserver(([entry]) => {
       this.isInViewport = entry?.isIntersecting ?? true;
-      this.setCurrentSpeed(this.ownerDocument.hidden || !this.isInViewport ? 0 : this.speed);
+      this.updateCurrentSpeed();
     });
 
     this.intersectionObserver.observe(this.parentElement);
@@ -509,7 +509,12 @@ export class ShaderMount {
   public setSpeed = (newSpeed = 1): void => {
     // Set the new animation speed
     this.speed = newSpeed;
-    this.setCurrentSpeed(this.ownerDocument.hidden || !this.isInViewport ? 0 : newSpeed);
+    this.updateCurrentSpeed();
+  };
+
+  /** Apply the target speed, pausing (0) while the tab is hidden or the element is out of the viewport */
+  private updateCurrentSpeed = (): void => {
+    this.setCurrentSpeed(this.ownerDocument.hidden || !this.isInViewport ? 0 : this.speed);
   };
 
   private setCurrentSpeed = (newSpeed: number): void => {
@@ -551,7 +556,7 @@ export class ShaderMount {
   };
 
   private handleDocumentVisibilityChange = () => {
-    this.setCurrentSpeed(this.ownerDocument.hidden || !this.isInViewport ? 0 : this.speed);
+    this.updateCurrentSpeed();
   };
 
   /** Dispose of the shader mount, cleaning up all of the WebGL resources */

--- a/packages/shaders/src/shader-mount.ts
+++ b/packages/shaders/src/shader-mount.ts
@@ -175,7 +175,6 @@ export class ShaderMount {
   private devicePixelsSupported = false;
 
   private intersectionObserver: IntersectionObserver | null = null;
-  /** Whether the parent element is currently intersecting the viewport */
   private isInViewport = true;
 
   private resizeObserver: ResizeObserver | null = null;

--- a/packages/shaders/src/shader-mount.ts
+++ b/packages/shaders/src/shader-mount.ts
@@ -201,9 +201,11 @@ export class ShaderMount {
   };
 
   private setupIntersectionObserver = () => {
-    if (typeof IntersectionObserver === 'undefined') return;
+    // checking ownerDocument for iframe and Picture-in-Picture cases
+    const view = this.ownerDocument.defaultView;
+    if (!view?.IntersectionObserver) return;
 
-    this.intersectionObserver = new IntersectionObserver(([entry]) => {
+    this.intersectionObserver = new view.IntersectionObserver(([entry]) => {
       this.isInViewport = entry?.isIntersecting ?? true;
       this.setCurrentSpeed(this.ownerDocument.hidden || !this.isInViewport ? 0 : this.speed);
     });

--- a/packages/shaders/src/shader-mount.ts
+++ b/packages/shaders/src/shader-mount.ts
@@ -200,7 +200,7 @@ export class ShaderMount {
   };
 
   private setupIntersectionObserver = () => {
-    // checking ownerDocument for iframe and Picture-in-Picture cases
+    // we check element's own window to support shaders used within iframe/PiP elements
     const view = this.ownerDocument.defaultView;
     if (!view?.IntersectionObserver) return;
 


### PR DESCRIPTION
## What and why

Animated shaders ran their `requestAnimationFrame` loop continuously, even
when the element was completely scrolled out of view. On a page with a
`MeshGradient` hero section, for example, scrolling down to content meant
the shader kept burning GPU cycles and battery the whole time — the user
could never escape it short of switching tabs.

The library already paused shaders when the browser tab was hidden
(`visibilitychange`). This PR extends that same pattern one step further:
also pause when the *element itself* is not visible in the viewport.

Closes #188.

## How it works

A single file changed: `packages/shaders/src/shader-mount.ts`.

An `IntersectionObserver` is set up in the constructor alongside the existing
`ResizeObserver`. When the element leaves the viewport it calls
`setCurrentSpeed(0)` — the same codepath already used by the tab-visibility
pause. When the element re-enters the viewport it calls
`setCurrentSpeed(this.speed)` and the animation resumes from exactly where
it left off (`currentFrame` is preserved, so there's no visual jump).

`setSpeed()` and `handleDocumentVisibilityChange()` are updated to check both
conditions together:

\`\`\`ts
this.setCurrentSpeed(this.ownerDocument.hidden || !this.isInViewport ? 0 : this.speed);
\`\`\`

`dispose()` disconnects the observer to avoid memory leaks.

## Behaviour summary

| Scenario | Before | After |
|---|---|---|
| Animated shader scrolled off-screen | RAF runs | RAF paused |
| Scrolled back into view | N/A | Resumes from same frame |
| Tab hidden | RAF paused | RAF paused (unchanged) |
| Static shader (`speed=0`) | No RAF | No RAF (unchanged) |
| `setFrame()` scrubbing off-screen | Works | Works (calls `render()` directly) |
| SSR | Works | Works (`typeof IntersectionObserver` guard) |

## Why this approach

- **Zero API surface change** — no new props, no opt-in. All consumers benefit
  automatically, same as the existing `visibilitychange` pause.
- **Zero bundle cost** — native browser API, no polyfill needed. Supported in
  every browser that supports WebGL2.
- **Zero perf cost while in view** — IntersectionObserver fires only on
  crossing events, not on every frame.
- **Follows the existing pattern exactly** — the `visibilitychange` pause is
  already unconditional; this is a direct extension of that design decision.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-file behavior change in the render loop; mirrors existing tab-visibility pause and uses a standard browser API with a no-op when unavailable.
> 
> **Overview**
> Animated shaders no longer keep their `requestAnimationFrame` loop running when the mount element is scrolled off-screen. **`ShaderMount`** now watches intersection with the viewport (using the element’s own `window` for iframe/PiP) and pauses the same way as when the tab is hidden.
> 
> **`setSpeed`**, **`visibilitychange`**, and the new observer all funnel through **`updateCurrentSpeed`**, which sets effective speed to **0** when the document is hidden **or** the element is not intersecting, otherwise restores **`this.speed`**. **`currentFrame`** is unchanged, so animation resumes without a time jump. The observer is disconnected in **`dispose`**. No new public API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f67953466af06104ab5bc6d790ee6ad574fd9f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->