### PR TITLE
fix(docs): make Leva select dropdown readable in dark mode

### DIFF
--- a/docs/src/index.css
+++ b/docs/src/index.css
@@ -195,6 +195,20 @@
       outline-offset: 2px;
     }
 
+    /* Leva renders an opacity:0 native <select> over a fake div. The native
+       dropdown popup it opens has no colors set, so in dark mode it paints
+       dark text on a dark background. Give the select + options explicit,
+       theme-aware colors so the popup stays readable. */
+    & select {
+      color: var(--color-foreground);
+      background-color: var(--color-leva-background);
+    }
+
+    & select option {
+      color: var(--color-foreground);
+      background-color: var(--color-leva-background);
+    }
+
     & div:has(> input):hover {
       box-shadow: none !important;
     }


### PR DESCRIPTION
## Problem

In dark mode, the Leva controls' `shape` dropdown (and any other select control) was nearly unreadable — the option list rendered dark text on a dark background.

**Root cause:** Leva renders the select as an `opacity: 0` native `<select>` layered under a presentational `<div>`. Clicking opens the browser's native dropdown popup, but Leva never sets a `color`/`background-color` on the `<select>` or its `<option>`s. With no colors set, the OS paints the popup using defaults, which collapses to dark-on-dark under a dark color scheme.

## Fix

Give the `<select>` and its `<option>` elements explicit, theme-aware colors in the existing `[data-leva-container]` block, reusing the same `light-dark()` CSS variables the rest of the panel uses. Readable in both light and dark mode, no JS changes.

```css
& select {
  color: var(--color-foreground);
  background-color: var(--color-leva-background);
}
& select option {
  color: var(--color-foreground);
  background-color: var(--color-leva-background);
}
```

## Before / After

| Before | After |
|:---:|:---:|
| ![before](https://raw.githubusercontent.com/amitdevv/shaders/pr-assets/leva-dropdown/before.png) | ![after](https://raw.githubusercontent.com/amitdevv/shaders/pr-assets/leva-dropdown/after.png) |

## Testing

- Ran the docs dev server (`bun run dev`) and opened `/grain-gradient`
- Opened the `shape` dropdown in dark mode — all options are now legible
- Confirmed light mode is unaffected
