### PR TITLE
Fix unloaded HTMLImageElement uniforms

### DIFF
--- a/packages/shaders-react/src/shader-mount.tsx
+++ b/packages/shaders-react/src/shader-mount.tsx
@@ -105,8 +105,11 @@ async function processUniforms(uniformsProp: ShaderMountUniformsReact): Promise<
 
       imageLoadPromises.push(imagePromise);
     } else if (value instanceof HTMLImageElement) {
-      setMinImageSize(value);
-      processedUniforms[key] = value;
+      const imagePromise = value.decode().then(() => {
+        setMinImageSize(value);
+        processedUniforms[key] = value;
+      });
+      imageLoadPromises.push(imagePromise);
     } else {
       processedUniforms[key] = value;
     }


### PR DESCRIPTION
## Summary

Wait for `HTMLImageElement` uniforms to finish decoding before passing them to the vanilla `ShaderMount`.

Fixes race condition: `Uncaught (in promise) Error: Paper Shaders: image for uniform u_noiseTexture must be fully loaded` for cache miss.

## Problem

Some shaders create image uniforms internally, such as the embedded `u_noiseTexture`. `processUniforms` currently passes these images through immediately, even if they have not finished loading.

On a cold page load, WebGL can therefore receive an image with a zero `naturalWidth` and throw:

> Paper Shaders: image for uniform u_noiseTexture must be fully loaded

## Change

Use `HTMLImageElement.decode()` and add its promise to the existing `imageLoadPromises` collection. This uses the same waiting mechanism already used for string image uniforms.

This is a follow-up to #244 and #253.

## Verification

- `bun run build`
- `bun run --filter @paper-design/shaders-react type-check`
- Verified against a `GrainGradient` cold-load failure in a React application
