### PR TITLE
FIX unnecessary uniform reprocessing when values are unchanged

### DIFF
--- a/packages/shaders-react/src/shader-mount.tsx
+++ b/packages/shaders-react/src/shader-mount.tsx
@@ -10,6 +10,7 @@ import {
 } from '@paper-design/shaders';
 import { useMergeRefs } from './use-merge-refs.js';
 import { setMinImageSize } from './set-min-image-size.js';
+import { uniformsAreEqual } from './uniforms-are-equal.js';
 
 /**
  * React Shader Mount can also accept strings as uniform values, which will assumed to be URLs and loaded as images
@@ -46,6 +47,35 @@ export interface ShaderComponentProps extends Omit<React.ComponentProps<'div'>, 
   width?: string | number;
   /** Inline CSS height style */
   height?: string | number;
+}
+
+const imageLoadCache = new Map<string, Promise<HTMLImageElement>>();
+
+async function loadImageFromUrl(url: string, external: boolean): Promise<HTMLImageElement> {
+  const cached = imageLoadCache.get(url);
+  if (cached) {
+    return cached;
+  }
+
+  const promise = new Promise<HTMLImageElement>((resolve, reject) => {
+    const img = new Image();
+    if (external) {
+      img.crossOrigin = 'anonymous';
+    }
+    img.onload = () => {
+      setMinImageSize(img);
+      resolve(img);
+    };
+    img.onerror = () => {
+      imageLoadCache.delete(url);
+      console.error(`Could not set uniforms. Failed to load image at ${url}`);
+      reject(new Error(`Failed to load image at ${url}`));
+    };
+    img.src = url;
+  });
+
+  imageLoadCache.set(url, promise);
+  return promise;
 }
 
 /** Parse the provided uniforms, turning URL strings into loaded images */
@@ -86,21 +116,8 @@ async function processUniforms(uniformsProp: ShaderMountUniformsReact): Promise<
         return;
       }
 
-      const imagePromise = new Promise<void>((resolve, reject) => {
-        const img = new Image();
-        if (isExternalUrl(url)) {
-          img.crossOrigin = 'anonymous';
-        }
-        img.onload = () => {
-          setMinImageSize(img);
-          processedUniforms[key] = img;
-          resolve();
-        };
-        img.onerror = () => {
-          console.error(`Could not set uniforms. Failed to load image at ${url}`);
-          reject();
-        };
-        img.src = url;
+      const imagePromise = loadImageFromUrl(url, isExternalUrl(url)).then((img) => {
+        processedUniforms[key] = img;
       });
 
       imageLoadPromises.push(imagePromise);
@@ -142,6 +159,7 @@ export const ShaderMount: React.FC<ShaderMountProps> = forwardRef<PaperShaderEle
     const divRef = useRef<PaperShaderElement>(null);
     const shaderMountRef: React.RefObject<ShaderMountVanilla | null> = useRef<ShaderMountVanilla>(null);
     const webGlContextAttributesRef = useRef(webGlContextAttributes);
+    const lastUniformsRef = useRef<ShaderMountUniformsReact | null>(null);
 
     // Initialize the ShaderMountVanilla
     useEffect(() => {
@@ -168,6 +186,7 @@ export const ShaderMount: React.FC<ShaderMountProps> = forwardRef<PaperShaderEle
       initShader();
 
       return () => {
+        lastUniformsRef.current = null;
         shaderMountRef.current?.dispose();
         shaderMountRef.current = null;
       };
@@ -175,6 +194,16 @@ export const ShaderMount: React.FC<ShaderMountProps> = forwardRef<PaperShaderEle
 
     // Uniforms
     useEffect(() => {
+      if (!isInitialized) {
+        return;
+      }
+
+      if (lastUniformsRef.current !== null && uniformsAreEqual(lastUniformsRef.current, uniformsProp)) {
+        return;
+      }
+
+      lastUniformsRef.current = uniformsProp;
+
       let isStale = false;
 
       const updateUniforms = async () => {

--- a/packages/shaders-react/src/uniforms-are-equal.ts
+++ b/packages/shaders-react/src/uniforms-are-equal.ts
@@ -1,0 +1,49 @@
+type UniformValue = string | boolean | number | number[] | number[][] | HTMLImageElement | undefined;
+
+function uniformValuesAreEqual(a: UniformValue, b: UniformValue): boolean {
+  if (Object.is(a, b)) {
+    return true;
+  }
+
+  if (a === undefined || b === undefined) {
+    return a === b;
+  }
+
+  if (typeof a !== typeof b) {
+    return false;
+  }
+
+  if (a instanceof HTMLImageElement && b instanceof HTMLImageElement) {
+    return a.src === b.src && a.naturalWidth === b.naturalWidth && a.naturalHeight === b.naturalHeight;
+  }
+
+  if (Array.isArray(a) && Array.isArray(b)) {
+    if (a.length !== b.length) {
+      return false;
+    }
+
+    return a.every((item, index) => uniformValuesAreEqual(item as UniformValue, b[index] as UniformValue));
+  }
+
+  return false;
+}
+
+export function uniformsAreEqual(
+  prevUniforms: Record<string, UniformValue>,
+  nextUniforms: Record<string, UniformValue>
+): boolean {
+  const prevKeys = Object.keys(prevUniforms);
+  const nextKeys = Object.keys(nextUniforms);
+
+  if (prevKeys.length !== nextKeys.length) {
+    return false;
+  }
+
+  for (const key of prevKeys) {
+    if (!uniformValuesAreEqual(prevUniforms[key], nextUniforms[key])) {
+      return false;
+    }
+  }
+
+  return true;
+}


### PR DESCRIPTION
Closes #275 

## To Test Locally:
Create a simple nextjs repo and import the local build of this branch.
In package.json of the nextjs repo import in dependencies via:
```json
"@paper-design/shaders-react": "file:../packages/shaders-react" // or your file path of the local build
```
In page.tsx of the nextjs repo add the following code:
```typescript
'use client';

import { useEffect, useState } from 'react';
import { Water } from '@paper-design/shaders-react';

export default function Demo() {
  const [tick, setTick] = useState(0);

  // Parent re-renders every second; Water props stay the same
  useEffect(() => {
    const id = setInterval(() => setTick((t) => t + 1), 1000);
    return () => clearInterval(id);
  }, []);

  return (
    <div>
      <p>tick: {tick}</p>
      <Water image="/test.png" style={{ width: 400, height: 400 }} />
    </div>
  );
}
```
Make sure to add an image named `test.png` to the public folder. Then simply run the app.

## Working proof:

https://github.com/user-attachments/assets/df0c0ef2-7e40-45c5-bab1-de01fb7ad2b2

