### PR TITLE
fix(docs): add missing shaders to shadcn registry

### DIFF
--- a/docs/registry.json
+++ b/docs/registry.json
@@ -327,6 +327,58 @@
           "type": "registry:component"
         }
       ]
+    },
+    {
+      "name": "halftone-dots",
+      "type": "registry:component",
+      "title": "Halftone Dots Example",
+      "description": "Halftone Dots shader example.",
+      "dependencies": ["@paper-design/shaders-react"],
+      "files": [
+        {
+          "path": "registry/halftone-dots-example.tsx",
+          "type": "registry:component"
+        }
+      ]
+    },
+    {
+      "name": "heatmap",
+      "type": "registry:component",
+      "title": "Heatmap Example",
+      "description": "Heatmap shader example.",
+      "dependencies": ["@paper-design/shaders-react"],
+      "files": [
+        {
+          "path": "registry/heatmap-example.tsx",
+          "type": "registry:component"
+        }
+      ]
+    },
+    {
+      "name": "halftone-cmyk",
+      "type": "registry:component",
+      "title": "Halftone CMYK Example",
+      "description": "Halftone CMYK shader example.",
+      "dependencies": ["@paper-design/shaders-react"],
+      "files": [
+        {
+          "path": "registry/halftone-cmyk-example.tsx",
+          "type": "registry:component"
+        }
+      ]
+    },
+    {
+      "name": "gem-smoke",
+      "type": "registry:component",
+      "title": "Gem Smoke Example",
+      "description": "Gem Smoke shader example.",
+      "dependencies": ["@paper-design/shaders-react"],
+      "files": [
+        {
+          "path": "registry/gem-smoke-example.tsx",
+          "type": "registry:component"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Four shaders have example files in `docs/registry/` but no entry in
`registry.json`, so they can't be installed:

| Shader | Landed in |
|---|---|
| `heatmap` | #238 |
| `halftone-dots` | #238 |
| `halftone-cmyk` | #240 |
| `gem-smoke` | #235 |

`https://shaders.paper.design/r/heatmap.json` → 404

Adds the four missing entries, following the existing shape. Verified with
`shadcn build` — 29 items, all generate. No other files touched.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation/registry metadata only; no runtime or security-sensitive code changes.
> 
> **Overview**
> Registers four shader examples that already lived under `docs/registry/` but were missing from `registry.json`, so shadcn install URLs (e.g. `/r/heatmap.json`) returned 404.
> 
> Adds registry items for **halftone-dots**, **heatmap**, **halftone-cmyk**, and **gem-smoke**, each pointing at the existing `*-example.tsx` files and declaring `@paper-design/shaders-react` like the other entries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d670c1706118a0e79e8b3932a95a2ac23eb7e99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->