### PR TITLE
fix(docs): add missing shaders to shaderDefs

### DIFF
--- a/docs/src/shader-defs/shader-defs.ts
+++ b/docs/src/shader-defs/shader-defs.ts
@@ -26,6 +26,9 @@ import { warpDef } from './warp-def';
 import { waterDef } from './water-def';
 import { wavesDef } from './waves-def';
 import { halftoneDotsDef } from './halftone-dots-def';
+import { halftoneCmykDef } from './halftone-cmyk-def';
+import { heatmapDef } from './heatmap-def';
+import { gemSmokeDef } from './gem-smoke-def';
 
 export const shaderDefs: ShaderDef[] = [
   grainGradientDef,
@@ -54,4 +57,7 @@ export const shaderDefs: ShaderDef[] = [
   imageDitheringDef,
   waterDef,
   halftoneDotsDef,
+  halftoneCmykDef,
+  heatmapDef,
+  gemSmokeDef,
 ];


### PR DESCRIPTION
`heatmap`, `halftone-cmyk` and `gem-smoke` have def files in `docs/src/shader-defs/`
but were never added to the `shaderDefs` array. `generate-llms-txt.ts` iterates that
array, so the published llms.txt is missing them:

```
$ curl -s https://shaders.paper.design/llms-full.txt | grep -c '^### '
26
```

29 shaders ship. Adds the three imports and array entries — regenerating gives 29.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation registry only; no runtime shader or API behavior changes.
> 
> **Overview**
> **Fixes incomplete published shader docs** by registering three shaders that already had def files but were omitted from the central `shaderDefs` list.
> 
> Adds imports and array entries for `halftoneCmykDef`, `heatmapDef`, and `gemSmokeDef` in `shader-defs.ts`, so `generate-llms-txt.ts` (which iterates `shaderDefs`) includes them in `llms-full.txt`—bringing the documented count from 26 to 29 shaders.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c97bab71b26bc73f9457eb2a31407842fcc038c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->