### PR TITLE
Add skill files

### DIFF
--- a/skills/paper-shaders/SKILL.md
+++ b/skills/paper-shaders/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: paper-shaders
+description: Implement, convert, customize, debug, or review Paper Shaders effects in React or vanilla JavaScript using `@paper-design/shaders-react` and `@paper-design/shaders`.
+---
+
+# Paper Shaders
+
+Implement Paper Shaders from the package source contract. Do not infer prop names, defaults, enum values, uniform mappings, color limits, or image behavior.
+
+## Workflow
+
+1. Inspect the target project's package manager and installed Paper Shaders package/version. Preserve the existing framework and dependency style.
+2. Read [references/usage.md](references/usage.md) before writing integration code.
+3. Read only the relevant file under [Shader references](#shader-references). Use its exact component export, fragment-shader export, props, defaults, enum options, and implementation capacity.
+4. For React, prefer the named shader component. Use the low-level React `ShaderMount` only for a custom fragment shader or an explicitly requested uniform-level integration.
+5. For vanilla JavaScript or TypeScript, reproduce the named React component's uniform construction. Apply every conversion and special requirement listed in `usage.md` and the matching shader reference.
+6. Give the mount element an explicit rendered size. Keep shader props separate from layout styles and ordinary DOM props.
+7. Verify with the project's type-check/build and, when rendering is available, inspect the result at the intended dimensions.
+
+## Source authority
+
+- Treat `packages/shaders/src/shaders/*.ts` and `packages/shaders-react/src/shaders/*.tsx` as authoritative for runtime behavior, types, defaults, enum mappings, and uniforms.
+- Treat `packages/shaders/src/shader-mount.ts`, `packages/shaders/src/shader-sizing.ts`, and `packages/shaders-react/src/shader-mount.tsx` as authoritative for mounting, images, sizing, motion, and performance controls.
+- Treat numeric ranges and steps in `docs/src/shader-defs/*-def.ts` as editor guidance, not runtime validation. Components pass values through without clamping.
+- Resolve source contradictions in favor of the shader implementation and its exported types/constants. Never repeat a stale prose claim when an array size, type, constant, or component mapping contradicts it.
+- Recheck current source when working against a different repository revision. Do not assume this reference overrides changed code.
+
+## Implementation rules
+
+- Import only public exports from the package entry point.
+- Use `@paper-design/shaders-react` for named React components and presets.
+- Use `@paper-design/shaders` for `ShaderMount`, fragment shaders, uniform types, enum maps, color conversion, noise textures, and image preprocessors.
+- Supply all required initial vanilla uniforms. `ShaderMount` records uniform locations from the constructor's initial uniform object; later partial updates cannot introduce an unregistered uniform.
+- Dispose vanilla mounts during teardown.
+- Keep color arrays non-empty and do not exceed the shader reference's implementation capacity for colors or other fixed-size loops.
+- Do not pass CSS named colors. The source color parser accepts hex, `rgb`/`rgba`, and `hsl`/`hsla` syntax.
+- Do not use deprecated React aliases in new code.
+
+## References
+
+- [Usage and integration](references/usage.md): React, vanilla, common controls, uniform conversion, images, lifecycle, and special cases.
+
+## Shader references
+
+Read only the file for the shader being used:
+
+- [Color Panels](references/shaders/color-panels.md)
+- [Dithering](references/shaders/dithering.md)
+- [Dot Grid](references/shaders/dot-grid.md)
+- [Dot Orbit](references/shaders/dot-orbit.md)
+- [Fluted Glass](references/shaders/fluted-glass.md)
+- [Gem Smoke](references/shaders/gem-smoke.md)
+- [God Rays](references/shaders/god-rays.md)
+- [Grain Gradient](references/shaders/grain-gradient.md)
+- [Halftone CMYK](references/shaders/halftone-cmyk.md)
+- [Halftone Dots](references/shaders/halftone-dots.md)
+- [Heatmap](references/shaders/heatmap.md)
+- [Image Dithering](references/shaders/image-dithering.md)
+- [Liquid Metal](references/shaders/liquid-metal.md)
+- [Mesh Gradient](references/shaders/mesh-gradient.md)
+- [Metaballs](references/shaders/metaballs.md)
+- [Neuro Noise](references/shaders/neuro-noise.md)
+- [Paper Texture](references/shaders/paper-texture.md)
+- [Perlin Noise](references/shaders/perlin-noise.md)
+- [Pulsing Border](references/shaders/pulsing-border.md)
+- [Simplex Noise](references/shaders/simplex-noise.md)
+- [Smoke Ring](references/shaders/smoke-ring.md)
+- [Spiral](references/shaders/spiral.md)
+- [Static Mesh Gradient](references/shaders/static-mesh-gradient.md)
+- [Static Radial Gradient](references/shaders/static-radial-gradient.md)
+- [Swirl](references/shaders/swirl.md)
+- [Voronoi](references/shaders/voronoi.md)
+- [Warp](references/shaders/warp.md)
+- [Water](references/shaders/water.md)
+- [Waves](references/shaders/waves.md)

--- a/skills/paper-shaders/references/shaders/color-panels.md
+++ b/skills/paper-shaders/references/shaders/color-panels.md
@@ -1,0 +1,24 @@
+# Color Panels
+
+Use the listed implementation types, options, capacities, exports, and defaults. Values labeled “editor range” come from the documentation UI definitions; the component does not clamp props to that range.
+
+Pseudo-3D semi-transparent panels rotating around a central axis.
+
+- React: `ColorPanels` and `colorPanelsPresets` from `@paper-design/shaders-react`.
+- Vanilla: `colorPanelsFragmentShader` and `ColorPanelsParams` from `@paper-design/shaders`.
+- Common controls: sizing and motion. Defaults: speed=0.5, frame=0, fit="contain", scale=0.8, rotation=0, offsetX=0, offsetY=0, originX=0.5, originY=0.5, worldWidth=0, worldHeight=0.
+- Source: `packages/shaders/src/shaders/color-panels.ts`, `packages/shaders-react/src/shaders/color-panels.tsx`, `docs/src/shader-defs/color-panels-def.ts`.
+
+| Prop | Type | Required | React default | Constraints | Effect |
+| --- | --- | --- | --- | --- | --- |
+| `colors` | `string[]` | no | `["#ff9d00","#fd4f30","#809bff","#6d2eff","#333aff","#f15cff","#ffd557"]` | — | Colors used by the shader; implementation capacity is 7. |
+| `colorBack` | `string` | no | `"#000000"` | — | Background color |
+| `angle1` | `number` | no | `0` | editor range: -1…1 | Skew angle applied to all panes |
+| `angle2` | `number` | no | `0` | editor range: -1…1 | Skew angle applied to all panes |
+| `length` | `number` | no | `1.1` | editor range: 0…3 | Panel length (relative to total height) |
+| `edges` | `boolean` | no | `false` | options: "true", "false" | Color highlight on the panels edges |
+| `blur` | `number` | no | `0` | editor range: 0…0.5 | Side blur (0 for sharp edges) |
+| `fadeIn` | `number` | no | `1` | editor range: 0…1 | Transparency near central axis |
+| `fadeOut` | `number` | no | `0.3` | editor range: 0…1 | Transparency near viewer |
+| `density` | `number` | no | `3` | editor range: 0.25…7 | Controls the angular spacing between panels |
+| `gradient` | `number` | no | `0` | editor range: 0…1 | Color mixing within a panel (0 = solid panel color, 1 = gradient of two colors) |

--- a/skills/paper-shaders/references/shaders/dithering.md
+++ b/skills/paper-shaders/references/shaders/dithering.md
@@ -1,0 +1,19 @@
+# Dithering
+
+Use the listed implementation types, options, capacities, exports, and defaults. Values labeled “editor range” come from the documentation UI definitions; the component does not clamp props to that range.
+
+Animated 2-color dithering over multiple pattern sources (noise, warp, dots, waves, ripple, swirl, sphere).
+
+- React: `Dithering` and `ditheringPresets` from `@paper-design/shaders-react`.
+- Vanilla: `ditheringFragmentShader` and `DitheringParams` from `@paper-design/shaders`.
+- Common controls: sizing and motion. Defaults: speed=1, frame=0, fit="none", scale=0.6, rotation=0, offsetX=0, offsetY=0, originX=0.5, originY=0.5, worldWidth=0, worldHeight=0.
+- Source: `packages/shaders/src/shaders/dithering.ts`, `packages/shaders-react/src/shaders/dithering.tsx`, `docs/src/shader-defs/dithering-def.ts`.
+
+| Prop | Type | Required | React default | Constraints | Effect |
+| --- | --- | --- | --- | --- | --- |
+| `colorBack` | `string` | no | `"#000000"` | — | Background color |
+| `colorFront` | `string` | no | `"#00b2ff"` | — | The foreground (ink) color |
+| `shape` | `DitheringShape` | no | `"sphere"` | options: "simplex", "warp", "dots", "wave", "ripple", "swirl", "sphere" | Shape pattern type |
+| `type` | `DitheringType` | no | `"4x4"` | options: "random", "2x2", "4x4", "8x8" | Dithering type |
+| `size` | `number` | no | `2` | editor range: 1…20; shader source documents 0.5…20 | Pixel size of dithering grid |
+| `pxSize` | `number` | no | — | — | React-only. @deprecated use `size` instead |

--- a/skills/paper-shaders/references/shaders/dot-grid.md
+++ b/skills/paper-shaders/references/shaders/dot-grid.md
@@ -1,0 +1,24 @@
+# Dot Grid
+
+Use the listed implementation types, options, capacities, exports, and defaults. Values labeled “editor range” come from the documentation UI definitions; the component does not clamp props to that range.
+
+Static grid pattern made of circles, diamonds, squares or triangles.
+
+- React: `DotGrid` and `dotGridPresets` from `@paper-design/shaders-react`.
+- Vanilla: `dotGridFragmentShader` and `DotGridParams` from `@paper-design/shaders`.
+- Common controls: sizing. Defaults: fit="none", scale=1, rotation=0, offsetX=0, offsetY=0, originX=0.5, originY=0.5, worldWidth=0, worldHeight=0.
+- React performance override: `maxPixelCount` defaults to `6016 * 3384`.
+- Source: `packages/shaders/src/shaders/dot-grid.ts`, `packages/shaders-react/src/shaders/dot-grid.tsx`, `docs/src/shader-defs/dot-grid-def.ts`.
+
+| Prop | Type | Required | React default | Constraints | Effect |
+| --- | --- | --- | --- | --- | --- |
+| `colorBack` | `string` | no | `"#000000"` | — | Background color |
+| `colorFill` | `string` | no | `"#ffffff"` | — | Shape fill color |
+| `colorStroke` | `string` | no | `"#ffaa00"` | — | Shape stroke color |
+| `size` | `number` | no | `2` | editor range: 1…100 | Base size of each shape, pixels |
+| `gapX` | `number` | no | `32` | editor range: 2…500 | Pattern horizontal spacing, pixels |
+| `gapY` | `number` | no | `32` | editor range: 2…500 | Pattern vertical spacing, pixels |
+| `strokeWidth` | `number` | no | `0` | editor range: 0…50 | The outline stroke width, pixels |
+| `sizeRange` | `number` | no | `0` | editor range: 0…1 | Random variation in shape size (0 = uniform size, higher = random value up to base size) |
+| `opacityRange` | `number` | no | `0` | editor range: 0…1 | Random variation in shape opacity (0 = all shapes opaque, higher = semi-transparent dots) |
+| `shape` | `DotGridShape` | no | `"circle"` | options: "circle", "diamond", "square", "triangle" | The shape type |

--- a/skills/paper-shaders/references/shaders/dot-orbit.md
+++ b/skills/paper-shaders/references/shaders/dot-orbit.md
@@ -1,0 +1,20 @@
+# Dot Orbit
+
+Use the listed implementation types, options, capacities, exports, and defaults. Values labeled “editor range” come from the documentation UI definitions; the component does not clamp props to that range.
+
+Animated multi-color dots pattern with each dot orbiting around its cell center. Supports up to 10 colors and various shape and motion controls.
+
+- React: `DotOrbit` and `dotOrbitPresets` from `@paper-design/shaders-react`.
+- Vanilla: `dotOrbitFragmentShader` and `DotOrbitParams` from `@paper-design/shaders`.
+- Common controls: sizing and motion. Defaults: speed=1.5, frame=0, fit="none", scale=1, rotation=0, offsetX=0, offsetY=0, originX=0.5, originY=0.5, worldWidth=0, worldHeight=0.
+- Vanilla requirements: create `u_noiseTexture` with `getShaderNoiseTexture()` and wait for the image to load before constructing `ShaderMount`.
+- Source: `packages/shaders/src/shaders/dot-orbit.ts`, `packages/shaders-react/src/shaders/dot-orbit.tsx`, `docs/src/shader-defs/dot-orbit-def.ts`.
+
+| Prop | Type | Required | React default | Constraints | Effect |
+| --- | --- | --- | --- | --- | --- |
+| `colorBack` | `string` | no | `"#000000"` | — | Background color |
+| `colors` | `string[]` | no | `["#ffc96b","#ff6200","#ff2f00","#421100","#1a0000"]` | — | Colors used by the shader; implementation capacity is 10. |
+| `size` | `number` | no | `1` | editor range: 0…1 | Dot radius relative to cell size |
+| `sizeRange` | `number` | no | `0` | editor range: 0…1 | Random variation in shape size (0 = uniform size, higher = random value up to base size) |
+| `spreading` | `number` | no | `1` | editor range: 0…1 | Maximum orbit distance |
+| `stepsPerColor` | `number` | no | `4` | editor range: 1…4; step: 1 | Number of extra colors between base colors (1 = N color palette, 2 = 2×N color palette, 3 = 3×N color palette, etc) |

--- a/skills/paper-shaders/references/shaders/fluted-glass.md
+++ b/skills/paper-shaders/references/shaders/fluted-glass.md
@@ -1,0 +1,38 @@
+# Fluted Glass
+
+Use the listed implementation types, options, capacities, exports, and defaults. Values labeled “editor range” come from the documentation UI definitions; the component does not clamp props to that range.
+
+Fluted glass image filter that transforms an image into streaked, ribbed distortions, giving a mix of clarity and obscurity.
+
+- React: `FlutedGlass` and `flutedGlassPresets` from `@paper-design/shaders-react`.
+- Vanilla: `flutedGlassFragmentShader` and `FlutedGlassParams` from `@paper-design/shaders`.
+- Common controls: sizing and motion. Defaults: speed=0, frame=0, fit="cover", scale=1, rotation=0, offsetX=0, offsetY=0, originX=0.5, originY=0.5, worldWidth=0, worldHeight=0.
+- Vanilla requirements: pass `["u_image"]` as the `ShaderMount` mipmaps argument.
+- Enum source note: the documentation UI definition contains stale `facete`; the exported `GlassDistortionShapes` mapping and component type use `flat`.
+- Source: `packages/shaders/src/shaders/fluted-glass.ts`, `packages/shaders-react/src/shaders/fluted-glass.tsx`, `docs/src/shader-defs/fluted-glass-def.ts`.
+
+| Prop | Type | Required | React default | Constraints | Effect |
+| --- | --- | --- | --- | --- | --- |
+| `image` | `HTMLImageElement \| string` | no | `""` | — | The image to use for the effect |
+| `colorBack` | `string` | no | `"#00000000"` | — | Background color |
+| `colorShadow` | `string` | no | `"#000000"` | — | Shadows color |
+| `colorHighlight` | `string` | no | `"#ffffff"` | — | Highlights color |
+| `shadows` | `number` | no | `0.25` | editor range: 0…1 | A color gradient added over both image and background, following the distortion shape |
+| `size` | `number` | no | `0.5` | editor range: 0…1; step: 0.001 | The size of the distortion shape grid |
+| `angle` | `number` | no | `0` | editor range: 0…180 | Direction of the grid relative to the image |
+| `distortion` | `number` | no | `0.5` | editor range: 0…1 | The power of distortion applied within each stripe |
+| `shift` | `number` | no | `0` | editor range: -1…1 | Texture shift in direction opposite to the grid |
+| `blur` | `number` | no | `0` | editor range: 0…1 | One-directional blur over the image and extra blur around the edges |
+| `edges` | `number` | no | `0.25` | editor range: 0…1 | Glass distortion and softness on the image edges |
+| `margin` | `number` | no | `0` | editor range: 0…1 | Distance from image edges to the effect |
+| `marginLeft` | `number` | no | `0` | editor range: 0…1 | Distance from the left edge to the effect |
+| `marginRight` | `number` | no | `0` | editor range: 0…1 | Distance from the right edge to the effect |
+| `marginTop` | `number` | no | `0` | editor range: 0…1 | Distance from the top edge to the effect |
+| `marginBottom` | `number` | no | `0` | editor range: 0…1 | Distance from the bottom edge to the effect |
+| `stretch` | `number` | no | `0` | editor range: 0…1 | Extra distortion along the grid lines |
+| `distortionShape` | `GlassDistortionShape` | no | `"prism"` | options: "prism", "lens", "contour", "cascade", "flat" | The shape of the distortion |
+| `highlights` | `number` | no | `0.1` | editor range: 0…1 | Thin strokes along the distortion shape; useful for antialiasing on a small grid |
+| `shape` | `GlassGridShape` | no | `"lines"` | options: "lines", "linesIrregular", "wave", "zigzag", "pattern" | The shape of the grid |
+| `grainMixer` | `number` | no | `0` | editor range: 0…1 | Strength of grain distortion applied to the shapes’ edges |
+| `grainOverlay` | `number` | no | `0` | editor range: 0…1 | Post-processing b/w grain overlay |
+| `count` | `number` | no | — | — | React-only. @deprecated use `size` instead |

--- a/skills/paper-shaders/references/shaders/gem-smoke.md
+++ b/skills/paper-shaders/references/shaders/gem-smoke.md
@@ -1,0 +1,27 @@
+# Gem Smoke
+
+Use the listed implementation types, options, capacities, exports, and defaults. Values labeled “editor range” come from the documentation UI definitions; the component does not clamp props to that range.
+
+Animated color fields placed over uploaded logo shape; gives the illusion of smoky noise behind the glassy shape.
+
+- React: `GemSmoke` and `gemSmokePresets` from `@paper-design/shaders-react`.
+- Vanilla: `gemSmokeFragmentShader` and `GemSmokeParams` from `@paper-design/shaders`.
+- Common controls: sizing and motion. Defaults: speed=1, frame=0, fit="contain", scale=0.6, rotation=0, offsetX=0, offsetY=0, originX=0.5, originY=0.5, worldWidth=0, worldHeight=0.
+- Vanilla requirements: preprocess image input with `toProcessedGemSmoke`; pass `["u_image"]` as the `ShaderMount` mipmaps argument.
+- Source: `packages/shaders/src/shaders/gem-smoke.ts`, `packages/shaders-react/src/shaders/gem-smoke.tsx`, `docs/src/shader-defs/gem-smoke-def.ts`.
+
+| Prop | Type | Required | React default | Constraints | Effect |
+| --- | --- | --- | --- | --- | --- |
+| `colors` | `string[]` | no | `["#333333","#e7e6df"]` | — | Colors used by the shader; implementation capacity is 6. |
+| `colorBack` | `string` | no | `"#f0efea"` | — | Background color |
+| `image` | `HTMLImageElement \| string \| undefined` | no | `""` | — | An optional image used as an effect mask. A transparent background is required. If no image is provided, the shader defaults to one of the predefined shapes. |
+| `innerDistortion` | `number` | no | `0.8` | editor range: 0…1 | The power of smoke distortion inside the input shape (shape defined by alpha channel) |
+| `outerDistortion` | `number` | no | `0.6` | editor range: 0…1 | The power of smoke distortion outside the input shape (shape defined by alpha channel) |
+| `outerGlow` | `number` | no | `0.55` | editor range: 0…1 | The visibility of smoke shape out of the input shape (shape defined by alpha channel) |
+| `innerGlow` | `number` | no | `1` | editor range: 0…1 | The visibility of smoke shape inside the input shape (shape defined by alpha channel) |
+| `colorInner` | `string` | no | `"#fafaf5"` | — | Additional color inside the input shape, mixing with smoke |
+| `offset` | `number` | no | `0` | editor range: -1…1 | Vertical offset of smoke inside the shape |
+| `angle` | `number` | no | `0` | editor range: 0…360 | Smoke direction |
+| `size` | `number` | no | `0.8` | editor range: 0…1 | The size of smoke shape relative to the image box |
+| `shape` | `GemSmokeShape` | no | `"diamond"` | options: "none", "circle", "daisy", "diamond", "metaballs" | The predefined shape used as an effect mask when no image is provided. |
+| `suspendWhenProcessingImage` | `boolean` | no | `false` | — | React-only. Suspends the component when the image is being processed. |

--- a/skills/paper-shaders/references/shaders/god-rays.md
+++ b/skills/paper-shaders/references/shaders/god-rays.md
@@ -1,0 +1,23 @@
+# God Rays
+
+Use the listed implementation types, options, capacities, exports, and defaults. Values labeled “editor range” come from the documentation UI definitions; the component does not clamp props to that range.
+
+Animated rays of light radiating from the center, blended with up to 5 colors.
+
+- React: `GodRays` and `godRaysPresets` from `@paper-design/shaders-react`.
+- Vanilla: `godRaysFragmentShader` and `GodRaysParams` from `@paper-design/shaders`.
+- Common controls: sizing and motion. Defaults: speed=0.75, frame=0, fit="contain", scale=1, rotation=0, offsetX=0, offsetY=-0.55, originX=0.5, originY=0.5, worldWidth=0, worldHeight=0.
+- Vanilla requirements: create `u_noiseTexture` with `getShaderNoiseTexture()` and wait for the image to load before constructing `ShaderMount`.
+- Source: `packages/shaders/src/shaders/god-rays.ts`, `packages/shaders-react/src/shaders/god-rays.tsx`, `docs/src/shader-defs/god-rays-def.ts`.
+
+| Prop | Type | Required | React default | Constraints | Effect |
+| --- | --- | --- | --- | --- | --- |
+| `colorBack` | `string` | no | `"#000000"` | — | Background color |
+| `colorBloom` | `string` | no | `"#0000ff"` | — | Color overlay blended with the rays |
+| `colors` | `string[]` | no | `["#a600ff6e","#6200fff0","#ffffff","#33fff5"]` | — | Colors used by the shader; implementation capacity is 5. |
+| `spotty` | `number` | no | `0.3` | editor range: 0…1 | The length of the rays |
+| `midSize` | `number` | no | `0.2` | editor range: 0…1 | Size of the circular glow shape in the center |
+| `midIntensity` | `number` | no | `0.4` | editor range: 0…1 | Brightness/intensity of the central glow |
+| `density` | `number` | no | `0.3` | editor range: 0…1 | The number of rays |
+| `intensity` | `number` | no | `0.8` | editor range: 0…1 | Visibility/strength of the rays |
+| `bloom` | `number` | no | `0.4` | editor range: 0…1 | Strength of the bloom/overlay effect |

--- a/skills/paper-shaders/references/shaders/grain-gradient.md
+++ b/skills/paper-shaders/references/shaders/grain-gradient.md
@@ -1,0 +1,20 @@
+# Grain Gradient
+
+Use the listed implementation types, options, capacities, exports, and defaults. Values labeled “editor range” come from the documentation UI definitions; the component does not clamp props to that range.
+
+Multi-color gradients with grainy, noise-textured distortion available in 7 animated abstract forms.
+
+- React: `GrainGradient` and `grainGradientPresets` from `@paper-design/shaders-react`.
+- Vanilla: `grainGradientFragmentShader` and `GrainGradientParams` from `@paper-design/shaders`.
+- Common controls: sizing and motion. Defaults: speed=1, frame=0, fit="contain", scale=1, rotation=0, offsetX=0, offsetY=0, originX=0.5, originY=0.5, worldWidth=0, worldHeight=0.
+- Vanilla requirements: create `u_noiseTexture` with `getShaderNoiseTexture()` and wait for the image to load before constructing `ShaderMount`.
+- Source: `packages/shaders/src/shaders/grain-gradient.ts`, `packages/shaders-react/src/shaders/grain-gradient.tsx`, `docs/src/shader-defs/grain-gradient-def.ts`.
+
+| Prop | Type | Required | React default | Constraints | Effect |
+| --- | --- | --- | --- | --- | --- |
+| `colorBack` | `string` | no | `"#000000"` | — | Background color |
+| `colors` | `string[]` | no | `["#7300ff","#eba8ff","#00bfff","#2a00ff"]` | — | Colors used by the shader; implementation capacity is 7. |
+| `softness` | `number` | no | `0.5` | editor range: 0…1 | Color transition sharpness (0 = hard edge, 1 = smooth gradient) |
+| `intensity` | `number` | no | `0.5` | editor range: 0…1 | Distortion between color bands |
+| `noise` | `number` | no | `0.25` | editor range: 0…1 | Grainy noise overlay |
+| `shape` | `GrainGradientShape` | no | `"corners"` | options: "wave", "dots", "truchet", "corners", "ripple", "blob", "sphere" | Shape type |

--- a/skills/paper-shaders/references/shaders/halftone-cmyk.md
+++ b/skills/paper-shaders/references/shaders/halftone-cmyk.md
@@ -1,0 +1,36 @@
+# Halftone CMYK
+
+Use the listed implementation types, options, capacities, exports, and defaults. Values labeled “editor range” come from the documentation UI definitions; the component does not clamp props to that range.
+
+CMYK halftone printing effect applied to images with customizable dot patterns and ink colors for each channel (Cyan, Magenta, Yellow, Black).
+
+- React: `HalftoneCmyk` and `halftoneCmykPresets` from `@paper-design/shaders-react`.
+- Vanilla: `halftoneCmykFragmentShader` and `HalftoneCmykParams` from `@paper-design/shaders`.
+- Common controls: sizing and motion. Defaults: speed=0, frame=0, fit="cover", scale=1, rotation=0, offsetX=0, offsetY=0, originX=0.5, originY=0.5, worldWidth=0, worldHeight=0.
+- Vanilla requirements: create `u_noiseTexture` with `getShaderNoiseTexture()` and wait for the image to load before constructing `ShaderMount`.
+- Source: `packages/shaders/src/shaders/halftone-cmyk.ts`, `packages/shaders-react/src/shaders/halftone-cmyk.tsx`, `docs/src/shader-defs/halftone-cmyk-def.ts`.
+
+| Prop | Type | Required | React default | Constraints | Effect |
+| --- | --- | --- | --- | --- | --- |
+| `image` | `HTMLImageElement \| string` | no | `""` | — | The image to use for the effect |
+| `colorBack` | `string` | no | `"#fbfaf5"` | — | Background (paper) color |
+| `colorC` | `string` | no | `"#00b4ff"` | — | Cyan ink color (alpha controls layer transparency, not dot size) |
+| `colorM` | `string` | no | `"#fc519f"` | — | Magenta ink color (alpha controls layer transparency, not dot size) |
+| `colorY` | `string` | no | `"#ffd800"` | — | Yellow ink color (alpha controls layer transparency, not dot size) |
+| `colorK` | `string` | no | `"#231f20"` | — | Black ink color (alpha controls layer transparency, not dot size) |
+| `size` | `number` | no | `0.2` | editor range: 0…1 | Grid size (relative to image box) |
+| `contrast` | `number` | no | `1` | editor range: 0…2 | Input image contrast |
+| `softness` | `number` | no | `1` | editor range: 0…1 | Dots edge softness |
+| `grainSize` | `number` | no | `0.5` | editor range: 0…1 | Size of grain overlay texture (relative to image box) |
+| `grainMixer` | `number` | no | `0` | editor range: 0…1 | Strength of grain affecting dot size |
+| `grainOverlay` | `number` | no | `0` | editor range: 0…1 | Strength of the black-and-white grain overlay on the final output |
+| `gridNoise` | `number` | no | `0.2` | editor range: 0…1 | Displaces both dot positions and color sampling points; naturally makes the background more visible |
+| `floodC` | `number` | no | `0.15` | editor range: 0…1; shader source documents -1…1 | Flat cyan dot-size adjustment applied uniformly |
+| `floodM` | `number` | no | `0` | editor range: 0…1; shader source documents -1…1 | Flat magenta dot-size adjustment applied uniformly |
+| `floodY` | `number` | no | `0` | editor range: 0…1; shader source documents -1…1 | Flat yellow dot-size adjustment applied uniformly |
+| `floodK` | `number` | no | `0` | editor range: 0…1; shader source documents -1…1 | Flat black dot-size adjustment applied uniformly |
+| `gainC` | `number` | no | `0.3` | editor range: -1…1 | Proportional cyan dot-size gain that enhances existing dots |
+| `gainM` | `number` | no | `0` | editor range: -1…1 | Proportional magenta dot-size gain that enhances existing dots |
+| `gainY` | `number` | no | `0.2` | editor range: -1…1 | Proportional yellow dot-size gain that enhances existing dots |
+| `gainK` | `number` | no | `0` | editor range: -1…1 | Proportional black dot-size gain that enhances existing dots |
+| `type` | `HalftoneCmykType` | no | `"ink"` | options: "dots", "ink", "sharp" | Dot type style (the difference between dots and ink is visible only with low softness) |

--- a/skills/paper-shaders/references/shaders/halftone-dots.md
+++ b/skills/paper-shaders/references/shaders/halftone-dots.md
@@ -1,0 +1,26 @@
+# Halftone Dots
+
+Use the listed implementation types, options, capacities, exports, and defaults. Values labeled “editor range” come from the documentation UI definitions; the component does not clamp props to that range.
+
+A halftone-dot image filter featuring customizable grids, color palettes, and dot styles.
+
+- React: `HalftoneDots` and `halftoneDotsPresets` from `@paper-design/shaders-react`.
+- Vanilla: `halftoneDotsFragmentShader` and `HalftoneDotsParams` from `@paper-design/shaders`.
+- Common controls: sizing and motion. Defaults: speed=0, frame=0, fit="cover", scale=1, rotation=0, offsetX=0, offsetY=0, originX=0.5, originY=0.5, worldWidth=0, worldHeight=0.
+- Source: `packages/shaders/src/shaders/halftone-dots.ts`, `packages/shaders-react/src/shaders/halftone-dots.tsx`, `docs/src/shader-defs/halftone-dots-def.ts`.
+
+| Prop | Type | Required | React default | Constraints | Effect |
+| --- | --- | --- | --- | --- | --- |
+| `image` | `HTMLImageElement \| string` | no | `""` | — | The image to use for the effect |
+| `colorFront` | `string` | no | `"#2b2b2b"` | — | Foreground color |
+| `colorBack` | `string` | no | `"#f2f1e8"` | — | Background color |
+| `size` | `number` | no | `0.5` | editor range: 0…1 | Grid size relative to the image box |
+| `grid` | `HalftoneDotsGrid` | no | `"hex"` | options: "square", "hex" | Dots grid type |
+| `radius` | `number` | no | `1.25` | editor range: 0…2 | Maximum dot size (relative to the grid cell) |
+| `contrast` | `number` | no | `0.4` | editor range: 0…1 | Contrast applied to the sampled image |
+| `originalColors` | `boolean` | no | `false` | options: "true", "false" | Use the sampled image’s original colors instead of colorFront |
+| `inverted` | `boolean` | no | `false` | options: "true", "false" | Inverts the image luminance, doesn’t affect the color scheme; not effective at zero contrast |
+| `grainMixer` | `number` | no | `0.2` | editor range: 0…1 | Strength of grain distortion applied to shape edges |
+| `grainOverlay` | `number` | no | `0.2` | editor range: 0…1 | Post-processing b/w grain overlay |
+| `grainSize` | `number` | no | `0.5` | editor range: 0…1 | The scale applied to both grain distortion and grain overlay |
+| `type` | `HalftoneDotsType` | no | `"gooey"` | options: "classic", "gooey", "holes", "soft" | Dot style |

--- a/skills/paper-shaders/references/shaders/heatmap.md
+++ b/skills/paper-shaders/references/shaders/heatmap.md
@@ -1,0 +1,23 @@
+# Heatmap
+
+Use the listed implementation types, options, capacities, exports, and defaults. Values labeled “editor range” come from the documentation UI definitions; the component does not clamp props to that range.
+
+A glowing gradient of colors flowing through an input shape. The effect creates a smoothly animated wave of intensity across the image.
+
+- React: `Heatmap` and `heatmapPresets` from `@paper-design/shaders-react`.
+- Vanilla: `heatmapFragmentShader` and `HeatmapParams` from `@paper-design/shaders`.
+- Common controls: sizing and motion. Defaults: speed=1, frame=0, fit="contain", scale=0.75, rotation=0, offsetX=0, offsetY=0, originX=0.5, originY=0.5, worldWidth=0, worldHeight=0.
+- Vanilla requirements: preprocess image input with `toProcessedHeatmap`; pass `["u_image"]` as the `ShaderMount` mipmaps argument.
+- Source: `packages/shaders/src/shaders/heatmap.ts`, `packages/shaders-react/src/shaders/heatmap.tsx`, `docs/src/shader-defs/heatmap-def.ts`.
+
+| Prop | Type | Required | React default | Constraints | Effect |
+| --- | --- | --- | --- | --- | --- |
+| `image` | `HTMLImageElement \| string` | yes | `""` | — | The image to use for the effect |
+| `contour` | `number` | no | `0.5` | editor range: 0…1 | The heat intensity near the edges of the input shape |
+| `angle` | `number` | no | `0` | editor range: 0…360 | The direction of the heatwaves (angle relative to the shape) |
+| `noise` | `number` | no | `0` | editor range: 0…1 | Grain applied across the entire graphic |
+| `innerGlow` | `number` | no | `0.5` | editor range: 0…1 | The size of the heated area inside the input shape |
+| `outerGlow` | `number` | no | `0.5` | editor range: 0…1 | Size of the heated area outside the input shape |
+| `colorBack` | `string` | no | `"#000000"` | — | Background color |
+| `colors` | `string[]` | no | `["#11206a","#1f3ba2","#2f63e7","#6bd7ff","#ffe679","#ff991e","#ff4c00"]` | — | Colors used by the shader; implementation capacity is 10. |
+| `suspendWhenProcessingImage` | `boolean` | no | `false` | — | React-only. Suspends the component when the image is being processed. |

--- a/skills/paper-shaders/references/shaders/image-dithering.md
+++ b/skills/paper-shaders/references/shaders/image-dithering.md
@@ -1,0 +1,23 @@
+# Image Dithering
+
+Use the listed implementation types, options, capacities, exports, and defaults. Values labeled “editor range” come from the documentation UI definitions; the component does not clamp props to that range.
+
+A dithering image filter with support for 4 dithering modes and multiple color palettes (2-color, 3-color, and multicolor options, using either predefined colors or colors sampled from the original image).
+
+- React: `ImageDithering` and `imageDitheringPresets` from `@paper-design/shaders-react`.
+- Vanilla: `imageDitheringFragmentShader` and `ImageDitheringParams` from `@paper-design/shaders`.
+- Common controls: sizing and motion. Defaults: speed=0, frame=0, fit="cover", scale=1, rotation=0, offsetX=0, offsetY=0, originX=0.5, originY=0.5, worldWidth=0, worldHeight=0.
+- Source: `packages/shaders/src/shaders/image-dithering.ts`, `packages/shaders-react/src/shaders/image-dithering.tsx`, `docs/src/shader-defs/image-dithering-def.ts`.
+
+| Prop | Type | Required | React default | Constraints | Effect |
+| --- | --- | --- | --- | --- | --- |
+| `image` | `HTMLImageElement \| string` | yes | `""` | — | The image to use for the effect |
+| `colorFront` | `string` | no | `"#94ffaf"` | — | Foreground color |
+| `colorBack` | `string` | no | `"#000c38"` | — | Background color |
+| `colorHighlight` | `string` | no | `"#eaff94"` | — | The secondary foreground color (set it same as colorFront to get a classic 2-color dithering) |
+| `type` | `DitheringType` | no | `"8x8"` | options: "random", "2x2", "4x4", "8x8" | Dithering type |
+| `size` | `number` | no | `2` | editor range: 0.5…20 | Pixel size of dithering grid; linked to the screen space, not to the image box |
+| `colorSteps` | `number` | no | `2` | editor range: 1…7; step: 1 | Number of colors to use (applies to both color modes) |
+| `originalColors` | `boolean` | no | `false` | options: "true", "false" | Use the original colors of the image |
+| `inverted` | `boolean` | no | `false` | — | Inverts image luminance without changing the color scheme. |
+| `pxSize` | `number` | no | — | — | React-only. @deprecated use `size` instead |

--- a/skills/paper-shaders/references/shaders/liquid-metal.md
+++ b/skills/paper-shaders/references/shaders/liquid-metal.md
@@ -1,0 +1,26 @@
+# Liquid Metal
+
+Use the listed implementation types, options, capacities, exports, and defaults. Values labeled “editor range” come from the documentation UI definitions; the component does not clamp props to that range.
+
+Futuristic liquid metal material applied to uploaded logo or abstract shape. Fluid motion imitation applied over user image with animated stripe pattern getting distorted along shape edges.
+
+- React: `LiquidMetal` and `liquidMetalPresets` from `@paper-design/shaders-react`.
+- Vanilla: `liquidMetalFragmentShader` and `LiquidMetalParams` from `@paper-design/shaders`.
+- Common controls: sizing and motion. Defaults: speed=1, frame=0, fit="contain", scale=0.6, rotation=0, offsetX=0, offsetY=0, originX=0.5, originY=0.5, worldWidth=0, worldHeight=0.
+- Vanilla requirements: preprocess image input with `toProcessedLiquidMetal`; pass `["u_image"]` as the `ShaderMount` mipmaps argument.
+- Source: `packages/shaders/src/shaders/liquid-metal.ts`, `packages/shaders-react/src/shaders/liquid-metal.tsx`, `docs/src/shader-defs/liquid-metal-def.ts`.
+
+| Prop | Type | Required | React default | Constraints | Effect |
+| --- | --- | --- | --- | --- | --- |
+| `colorBack` | `string` | no | `"#AAAAAC"` | — | Background color |
+| `colorTint` | `string` | no | `"#ffffff"` | — | Overlay color (color burn blending used) |
+| `image` | `HTMLImageElement \| string \| undefined` | no | `""` | — | An optional image used as an effect mask. A transparent background is required. If no image is provided, the shader defaults to one of the predefined shapes. |
+| `repetition` | `number` | no | `2` | editor range: 1…10 | Density of pattern stripes |
+| `shiftRed` | `number` | no | `0.3` | editor range: -1…1 | R-channel dispersion |
+| `shiftBlue` | `number` | no | `0.3` | editor range: -1…1 | B-channel dispersion |
+| `contour` | `number` | no | `0.4` | editor range: 0…1 | Strength of the distortion on the shape edges |
+| `softness` | `number` | no | `0.1` | editor range: 0…1 | Color transition sharpness (0 = hard edge, 1 = smooth gradient) |
+| `distortion` | `number` | no | `0.07` | editor range: 0…1 | Noise distortion over the stripes pattern |
+| `angle` | `number` | no | `70` | editor range: 0…360 | The direction of pattern animation (angle relative to the shape) |
+| `shape` | `LiquidMetalShape` | no | `"diamond"` | options: "none", "circle", "daisy", "diamond", "metaballs" | The predefined shape used as an effect mask when no image is provided. |
+| `suspendWhenProcessingImage` | `boolean` | no | `false` | — | React-only. Suspends the component when the image is being processed. |

--- a/skills/paper-shaders/references/shaders/mesh-gradient.md
+++ b/skills/paper-shaders/references/shaders/mesh-gradient.md
@@ -1,0 +1,18 @@
+# Mesh Gradient
+
+Use the listed implementation types, options, capacities, exports, and defaults. Values labeled “editor range” come from the documentation UI definitions; the component does not clamp props to that range.
+
+A flowing composition of color spots, moving along distinct trajectories and transformed by organic distortion.
+
+- React: `MeshGradient` and `meshGradientPresets` from `@paper-design/shaders-react`.
+- Vanilla: `meshGradientFragmentShader` and `MeshGradientParams` from `@paper-design/shaders`.
+- Common controls: sizing and motion. Defaults: speed=1, frame=0, fit="contain", scale=1, rotation=0, offsetX=0, offsetY=0, originX=0.5, originY=0.5, worldWidth=0, worldHeight=0.
+- Source: `packages/shaders/src/shaders/mesh-gradient.ts`, `packages/shaders-react/src/shaders/mesh-gradient.tsx`, `docs/src/shader-defs/mesh-gradient-def.ts`.
+
+| Prop | Type | Required | React default | Constraints | Effect |
+| --- | --- | --- | --- | --- | --- |
+| `colors` | `string[]` | no | `["#e0eaff","#241d9a","#f75092","#9f50d3"]` | — | Colors used by the shader; implementation capacity is 10. |
+| `distortion` | `number` | no | `0.8` | editor range: 0…1 | The power of organic noise distortion |
+| `swirl` | `number` | no | `0.1` | editor range: 0…1 | The power of vortex distortion |
+| `grainMixer` | `number` | no | `0` | editor range: 0…1 | Strength of grain distortion applied to the shapes’ edges |
+| `grainOverlay` | `number` | no | `0` | editor range: 0…1 | Post-processing b/w grain overlay |

--- a/skills/paper-shaders/references/shaders/metaballs.md
+++ b/skills/paper-shaders/references/shaders/metaballs.md
@@ -1,0 +1,18 @@
+# Metaballs
+
+Use the listed implementation types, options, capacities, exports, and defaults. Values labeled “editor range” come from the documentation UI definitions; the component does not clamp props to that range.
+
+Up to 20 colored gooey balls moving around the center and merging into smooth organic shapes.
+
+- React: `Metaballs` and `metaballsPresets` from `@paper-design/shaders-react`.
+- Vanilla: `metaballsFragmentShader` and `MetaballsParams` from `@paper-design/shaders`.
+- Common controls: sizing and motion. Defaults: speed=1, frame=0, fit="contain", scale=1, rotation=0, offsetX=0, offsetY=0, originX=0.5, originY=0.5, worldWidth=0, worldHeight=0.
+- Vanilla requirements: create `u_noiseTexture` with `getShaderNoiseTexture()` and wait for the image to load before constructing `ShaderMount`.
+- Source: `packages/shaders/src/shaders/metaballs.ts`, `packages/shaders-react/src/shaders/metaballs.tsx`, `docs/src/shader-defs/metaballs-def.ts`.
+
+| Prop | Type | Required | React default | Constraints | Effect |
+| --- | --- | --- | --- | --- | --- |
+| `colorBack` | `string` | no | `"#000000"` | — | Background color |
+| `colors` | `string[]` | no | `["#6e33cc","#ff5500","#ffc105","#ffc800","#f585ff"]` | — | Colors used by the shader; implementation capacity is 8. |
+| `count` | `number` | no | `10` | editor range: 1…20 | Number of balls |
+| `size` | `number` | no | `0.83` | editor range: 0…1 | The size of the balls |

--- a/skills/paper-shaders/references/shaders/neuro-noise.md
+++ b/skills/paper-shaders/references/shaders/neuro-noise.md
@@ -1,0 +1,18 @@
+# Neuro Noise
+
+Use the listed implementation types, options, capacities, exports, and defaults. Values labeled “editor range” come from the documentation UI definitions; the component does not clamp props to that range.
+
+A glowing, web-like structure of fluid lines and soft intersections. Great for creating atmospheric, organic-yet-futuristic visuals.
+
+- React: `NeuroNoise` and `neuroNoisePresets` from `@paper-design/shaders-react`.
+- Vanilla: `neuroNoiseFragmentShader` and `NeuroNoiseParams` from `@paper-design/shaders`.
+- Common controls: sizing and motion. Defaults: speed=1, frame=0, fit="none", scale=1, rotation=0, offsetX=0, offsetY=0, originX=0.5, originY=0.5, worldWidth=0, worldHeight=0.
+- Source: `packages/shaders/src/shaders/neuro-noise.ts`, `packages/shaders-react/src/shaders/neuro-noise.tsx`, `docs/src/shader-defs/neuro-noise-def.ts`.
+
+| Prop | Type | Required | React default | Constraints | Effect |
+| --- | --- | --- | --- | --- | --- |
+| `colorFront` | `string` | no | `"#ffffff"` | — | Graphics highlight color |
+| `colorMid` | `string` | no | `"#47a6ff"` | — | Graphics main color |
+| `colorBack` | `string` | no | `"#000000"` | — | Background color |
+| `brightness` | `number` | no | `0.05` | editor range: 0…1 | Luminosity of the crossing points |
+| `contrast` | `number` | no | `0.3` | editor range: 0…1 | Sharpness of the bright–dark transition |

--- a/skills/paper-shaders/references/shaders/paper-texture.md
+++ b/skills/paper-shaders/references/shaders/paper-texture.md
@@ -1,0 +1,32 @@
+# Paper Texture
+
+Use the listed implementation types, options, capacities, exports, and defaults. Values labeled “editor range” come from the documentation UI definitions; the component does not clamp props to that range.
+
+A static texture built from multiple noise layers, usable for realistic paper and cardboard surfaces. Can be used as an image filter or as a standalone texture.
+
+- React: `PaperTexture` and `paperTexturePresets` from `@paper-design/shaders-react`.
+- Vanilla: `paperTextureFragmentShader` and `PaperTextureParams` from `@paper-design/shaders`.
+- Common controls: sizing and motion. Defaults: speed=0, frame=0, fit="cover", scale=0.6, rotation=0, offsetX=0, offsetY=0, originX=0.5, originY=0.5, worldWidth=0, worldHeight=0.
+- Vanilla requirements: create `u_noiseTexture` with `getShaderNoiseTexture()` and wait for the image to load before constructing `ShaderMount`; pass `["u_image"]` as the `ShaderMount` mipmaps argument.
+- Source: `packages/shaders/src/shaders/paper-texture.ts`, `packages/shaders-react/src/shaders/paper-texture.tsx`, `docs/src/shader-defs/paper-texture-def.ts`.
+
+| Prop | Type | Required | React default | Constraints | Effect |
+| --- | --- | --- | --- | --- | --- |
+| `image` | `HTMLImageElement \| string` | no | `""` | — | The image to use for the effect |
+| `colorFront` | `string` | no | `"#9fadbc"` | — | Foreground color |
+| `colorBack` | `string` | no | `"#ffffff"` | — | Background color |
+| `contrast` | `number` | no | `0.3` | editor range: 0…1 | Blending behavior (sharper vs. smoother color transitions) |
+| `roughness` | `number` | no | `0.4` | editor range: 0…1 | Pixel noise, related to canvas (not scalable) |
+| `fiber` | `number` | no | `0.3` | editor range: 0…1 | Curly-shaped noise |
+| `fiberSize` | `number` | no | `0.2` | editor range: 0…1 | Curly-shaped noise scale |
+| `crumples` | `number` | no | `0.3` | editor range: 0…1 | Cell-based crumple pattern |
+| `foldCount` | `number` | no | `5` | editor range: 1…15; step: 1 | Number of folds (15 max) |
+| `folds` | `number` | no | `0.65` | editor range: 0…1 | Depth of the folds |
+| `fade` | `number` | no | `0` | editor range: 0…1 | Big-scale noise mask applied to the pattern |
+| `crumpleSize` | `number` | no | `0.35` | editor range: 0…1 | Cell-based crumple pattern scale |
+| `drops` | `number` | no | `0.2` | editor range: 0…1 | The visibility of speckle pattern |
+| `seed` | `number` | no | `5.8` | editor range: 0…1000 | Seed applied to folds, crumples and dots |
+| `fiberScale` | `number` | no | — | — | React-only. @deprecated use `fiberSize` instead |
+| `crumplesScale` | `number` | no | — | — | React-only. @deprecated use `crumpleSize` instead |
+| `foldsNumber` | `number` | no | — | — | React-only. @deprecated use `foldCount` instead |
+| `blur` | `number` | no | — | — | React-only. @deprecated use `fade` instead |

--- a/skills/paper-shaders/references/shaders/perlin-noise.md
+++ b/skills/paper-shaders/references/shaders/perlin-noise.md
@@ -1,0 +1,20 @@
+# Perlin Noise
+
+Use the listed implementation types, options, capacities, exports, and defaults. Values labeled “editor range” come from the documentation UI definitions; the component does not clamp props to that range.
+
+Classic animated 3D Perlin noise with exposed controls. Original algorithm: https://www.shadertoy.com/view/NlSGDz
+
+- React: `PerlinNoise` and `perlinNoisePresets` from `@paper-design/shaders-react`.
+- Vanilla: `perlinNoiseFragmentShader` and `PerlinNoiseParams` from `@paper-design/shaders`.
+- Common controls: sizing and motion. Defaults: speed=0.5, frame=0, fit="none", scale=1, rotation=0, offsetX=0, offsetY=0, originX=0.5, originY=0.5, worldWidth=0, worldHeight=0.
+- Source: `packages/shaders/src/shaders/perlin-noise.ts`, `packages/shaders-react/src/shaders/perlin-noise.tsx`, `docs/src/shader-defs/perlin-noise-def.ts`.
+
+| Prop | Type | Required | React default | Constraints | Effect |
+| --- | --- | --- | --- | --- | --- |
+| `colorFront` | `string` | no | `"#fccff7"` | — | Foreground color |
+| `colorBack` | `string` | no | `"#632ad5"` | — | Background color |
+| `proportion` | `number` | no | `0.35` | editor range: 0…1 | Blend point between 2 colors (0.5 = equal distribution) |
+| `softness` | `number` | no | `0.1` | editor range: 0…1 | Color transition sharpness (0 = hard edge, 1 = smooth gradient) |
+| `octaveCount` | `number` | no | `1` | editor range: 1…8; step: 1 | Perlin noise octaves number (more octaves for more detailed patterns) |
+| `persistence` | `number` | no | `1` | editor range: 0.3…1 | Roughness, falloff between octaves |
+| `lacunarity` | `number` | no | `1.5` | editor range: 1.5…10 | Frequency step, typically around 2. Defines how compressed the pattern is |

--- a/skills/paper-shaders/references/shaders/pulsing-border.md
+++ b/skills/paper-shaders/references/shaders/pulsing-border.md
@@ -1,0 +1,32 @@
+# Pulsing Border
+
+Use the listed implementation types, options, capacities, exports, and defaults. Values labeled “editor range” come from the documentation UI definitions; the component does not clamp props to that range.
+
+Luminous trails of color merging into a glowing gradient contour.
+
+- React: `PulsingBorder` and `pulsingBorderPresets` from `@paper-design/shaders-react`.
+- Vanilla: `pulsingBorderFragmentShader` and `PulsingBorderParams` from `@paper-design/shaders`.
+- Common controls: sizing and motion. Defaults: speed=1, frame=0, fit="contain", scale=0.6, rotation=0, offsetX=0, offsetY=0, originX=0.5, originY=0.5, worldWidth=0, worldHeight=0.
+- Vanilla requirements: create `u_noiseTexture` with `getShaderNoiseTexture()` and wait for the image to load before constructing `ShaderMount`.
+- Source: `packages/shaders/src/shaders/pulsing-border.ts`, `packages/shaders-react/src/shaders/pulsing-border.tsx`, `docs/src/shader-defs/pulsing-border-def.ts`.
+
+| Prop | Type | Required | React default | Constraints | Effect |
+| --- | --- | --- | --- | --- | --- |
+| `colorBack` | `string` | no | `"#000000"` | — | Background color |
+| `colors` | `string[]` | no | `["#0dc1fd","#d915ef","#ff3f2ecc"]` | — | Colors used by the shader; implementation capacity is 5. |
+| `roundness` | `number` | no | `0.25` | editor range: 0…1 | The border radius |
+| `thickness` | `number` | no | `0.1` | editor range: 0…1 | The border base width |
+| `margin` | `number` | no | `0` | editor range: 0…1 | Distance from canvas edges to the effect |
+| `marginLeft` | `number` | no | `0` | editor range: 0…1 | Distance from the left edge to the effect |
+| `marginRight` | `number` | no | `0` | editor range: 0…1 | Distance from the right edge to the effect |
+| `marginTop` | `number` | no | `0` | editor range: 0…1 | Distance from the top edge to the effect |
+| `marginBottom` | `number` | no | `0` | editor range: 0…1 | Distance from the bottom edge to the effect |
+| `aspectRatio` | `PulsingBorderAspectRatio` | no | `"auto"` | options: "auto", "square" | Aspect ratio of the effect |
+| `softness` | `number` | no | `0.75` | editor range: 0…1 | Border edge sharpness (0 = hard edge, 1 = smooth gradient) |
+| `intensity` | `number` | no | `0.2` | editor range: 0…1 | Thickness of individual color spots |
+| `bloom` | `number` | no | `0.25` | editor range: 0…1 | The power of glow (0 = normal color blending, 1 = fully additive blending) |
+| `spots` | `number` | no | `5` | editor range: 1…20; step: 1; shader loop capacity: 4 | Requested spots per color. The shader renders at most 4, so the default value of 5 has the same effective spot count as 4. |
+| `spotSize` | `number` | no | `0.5` | editor range: 0…1 | Angular size of spots |
+| `pulse` | `number` | no | `0.25` | editor range: 0…1 | Optional pulsing animation |
+| `smoke` | `number` | no | `0.3` | editor range: 0…1 | Optional noisy shape extending the border shape |
+| `smokeSize` | `number` | no | `0.6` | editor range: 0…1 | The size of the smoke effect (effective with smoke > 0) |

--- a/skills/paper-shaders/references/shaders/simplex-noise.md
+++ b/skills/paper-shaders/references/shaders/simplex-noise.md
@@ -1,0 +1,16 @@
+# Simplex Noise
+
+Use the listed implementation types, options, capacities, exports, and defaults. Values labeled “editor range” come from the documentation UI definitions; the component does not clamp props to that range.
+
+A multi-color gradient mapped into smooth, animated curves built as a combination of 2 Simplex noises.
+
+- React: `SimplexNoise` and `simplexNoisePresets` from `@paper-design/shaders-react`.
+- Vanilla: `simplexNoiseFragmentShader` and `SimplexNoiseParams` from `@paper-design/shaders`.
+- Common controls: sizing and motion. Defaults: speed=0.5, frame=0, fit="none", scale=0.6, rotation=0, offsetX=0, offsetY=0, originX=0.5, originY=0.5, worldWidth=0, worldHeight=0.
+- Source: `packages/shaders/src/shaders/simplex-noise.ts`, `packages/shaders-react/src/shaders/simplex-noise.tsx`, `docs/src/shader-defs/simplex-noise-def.ts`.
+
+| Prop | Type | Required | React default | Constraints | Effect |
+| --- | --- | --- | --- | --- | --- |
+| `colors` | `string[]` | no | `["#4449CF","#FFD1E0","#F94446","#FFD36B","#FFFFFF"]` | — | Colors used by the shader; implementation capacity is 10. |
+| `stepsPerColor` | `number` | no | `2` | editor range: 1…10; step: 1 | Number of extra colors between base colors (1 = N color palette, 2 = 2×N color palette, 3 = 3×N color palette, etc) |
+| `softness` | `number` | no | `0` | editor range: 0…1 | Color transition sharpness (0 = hard edge, 1 = smooth gradient) |

--- a/skills/paper-shaders/references/shaders/smoke-ring.md
+++ b/skills/paper-shaders/references/shaders/smoke-ring.md
@@ -1,0 +1,21 @@
+# Smoke Ring
+
+Use the listed implementation types, options, capacities, exports, and defaults. Values labeled “editor range” come from the documentation UI definitions; the component does not clamp props to that range.
+
+Radial multi-colored gradient shaped with layered noise for a natural, smoky aesthetic.
+
+- React: `SmokeRing` and `smokeRingPresets` from `@paper-design/shaders-react`.
+- Vanilla: `smokeRingFragmentShader` and `SmokeRingParams` from `@paper-design/shaders`.
+- Common controls: sizing and motion. Defaults: speed=0.5, frame=0, fit="contain", scale=0.8, rotation=0, offsetX=0, offsetY=0, originX=0.5, originY=0.5, worldWidth=0, worldHeight=0.
+- Vanilla requirements: create `u_noiseTexture` with `getShaderNoiseTexture()` and wait for the image to load before constructing `ShaderMount`.
+- Source: `packages/shaders/src/shaders/smoke-ring.ts`, `packages/shaders-react/src/shaders/smoke-ring.tsx`, `docs/src/shader-defs/smoke-ring-def.ts`.
+
+| Prop | Type | Required | React default | Constraints | Effect |
+| --- | --- | --- | --- | --- | --- |
+| `colorBack` | `string` | no | `"#000000"` | — | Background color |
+| `colors` | `string[]` | no | `["#ffffff"]` | — | Colors used by the shader; implementation capacity is 10. |
+| `noiseScale` | `number` | no | `3` | editor range: 0.01…5 | The noise frequency |
+| `thickness` | `number` | no | `0.65` | editor range: 0.01…1 | The thickness of the ring shape |
+| `radius` | `number` | no | `0.25` | editor range: 0…1 | The radius of the ring shape |
+| `innerShape` | `number` | no | `0.7` | editor range: 0…4 | The ring inner fill |
+| `noiseIterations` | `number` | no | `8` | editor range: 1…8; step: 1 | A number of noise layers, more layers gives more details |

--- a/skills/paper-shaders/references/shaders/spiral.md
+++ b/skills/paper-shaders/references/shaders/spiral.md
@@ -1,0 +1,23 @@
+# Spiral
+
+Use the listed implementation types, options, capacities, exports, and defaults. Values labeled “editor range” come from the documentation UI definitions; the component does not clamp props to that range.
+
+A single-colored animated spiral that morphs across a wide range of shapes - from crisp, thin-lined geometry to flowing whirlpool forms and wavy, abstract rings.
+
+- React: `Spiral` and `spiralPresets` from `@paper-design/shaders-react`.
+- Vanilla: `spiralFragmentShader` and `SpiralParams` from `@paper-design/shaders`.
+- Common controls: sizing and motion. Defaults: speed=1, frame=0, fit="none", scale=1, rotation=0, offsetX=0, offsetY=0, originX=0.5, originY=0.5, worldWidth=0, worldHeight=0.
+- Source: `packages/shaders/src/shaders/spiral.ts`, `packages/shaders-react/src/shaders/spiral.tsx`, `docs/src/shader-defs/spiral-def.ts`.
+
+| Prop | Type | Required | React default | Constraints | Effect |
+| --- | --- | --- | --- | --- | --- |
+| `colorBack` | `string` | no | `"#001429"` | — | Background color |
+| `colorFront` | `string` | no | `"#79D1FF"` | — | Foreground (ink) color |
+| `density` | `number` | no | `1` | editor range: 0…1 | Spacing falloff simulating perspective (0 = flat spiral) |
+| `distortion` | `number` | no | `0` | editor range: 0…1 | Power of shape distortion applied along the spiral |
+| `strokeWidth` | `number` | no | `0.5` | editor range: 0…1 | Thickness of spiral curve |
+| `strokeTaper` | `number` | no | `0` | editor range: 0…1 | How much the stroke loses width away from the center (0 = full visibility) |
+| `strokeCap` | `number` | no | `0` | editor range: 0…1 | Extra stroke width at the center (no effect with strokeWidth = 0.5) |
+| `noise` | `number` | no | `0` | editor range: 0…1 | Noise distortion applied over the canvas (no effect with noiseFrequency = 0) |
+| `noiseFrequency` | `number` | no | `0` | editor range: 0…1 | Noise frequency (no effect with noise = 0) |
+| `softness` | `number` | no | `0` | editor range: 0…1 | Color transition sharpness (0 = hard edge, 1 = smooth gradient) |

--- a/skills/paper-shaders/references/shaders/static-mesh-gradient.md
+++ b/skills/paper-shaders/references/shaders/static-mesh-gradient.md
@@ -1,0 +1,22 @@
+# Static Mesh Gradient
+
+Use the listed implementation types, options, capacities, exports, and defaults. Values labeled “editor range” come from the documentation UI definitions; the component does not clamp props to that range.
+
+Multi-point mesh gradient with up to 10 color spots, enhanced by two-direction warping, adjustable blend sharpness, and grain controls.
+
+- React: `StaticMeshGradient` and `staticMeshGradientPresets` from `@paper-design/shaders-react`.
+- Vanilla: `staticMeshGradientFragmentShader` and `StaticMeshGradientParams` from `@paper-design/shaders`.
+- Common controls: sizing and motion. Defaults: speed=0, frame=0, fit="contain", scale=1, rotation=270, offsetX=0, offsetY=0, originX=0.5, originY=0.5, worldWidth=0, worldHeight=0.
+- Source: `packages/shaders/src/shaders/static-mesh-gradient.ts`, `packages/shaders-react/src/shaders/static-mesh-gradient.tsx`, `docs/src/shader-defs/static-mesh-gradient-def.ts`.
+
+| Prop | Type | Required | React default | Constraints | Effect |
+| --- | --- | --- | --- | --- | --- |
+| `colors` | `string[]` | no | `["#ffad0a","#6200ff","#e2a3ff","#ff99fd"]` | — | Colors used by the shader; implementation capacity is 10. |
+| `positions` | `number` | no | `2` | editor range: 0…100 | Color spots placement |
+| `waveX` | `number` | no | `1` | editor range: 0…1 | Strength of sine wave distortion along X axis |
+| `waveXShift` | `number` | no | `0.6` | editor range: 0…1 | Phase offset applied to the X-axis wave |
+| `waveY` | `number` | no | `1` | editor range: 0…1 | Strength of sine wave distortion along Y axis |
+| `waveYShift` | `number` | no | `0.21` | editor range: 0…1 | Phase offset applied to the Y-axis wave |
+| `mixing` | `number` | no | `0.93` | editor range: 0…1 | Blending behavior: 0 gives hard stripes, 0.5 is smooth, and 1 gives a gradual blend |
+| `grainMixer` | `number` | no | `0` | editor range: 0…1 | Strength of grain distortion applied to the shapes’ edges |
+| `grainOverlay` | `number` | no | `0` | editor range: 0…1 | Post-processing b/w grain overlay |

--- a/skills/paper-shaders/references/shaders/static-radial-gradient.md
+++ b/skills/paper-shaders/references/shaders/static-radial-gradient.md
@@ -1,0 +1,25 @@
+# Static Radial Gradient
+
+Use the listed implementation types, options, capacities, exports, and defaults. Values labeled “editor range” come from the documentation UI definitions; the component does not clamp props to that range.
+
+Radial gradient with up to 10 blended colors, featuring advanced mixing modes, focal point controls, shape distortion, and grain effects.
+
+- React: `StaticRadialGradient` and `staticRadialGradientPresets` from `@paper-design/shaders-react`.
+- Vanilla: `staticRadialGradientFragmentShader` and `StaticRadialGradientParams` from `@paper-design/shaders`.
+- Common controls: sizing and motion. Defaults: speed=0, frame=0, fit="contain", scale=1, rotation=0, offsetX=0, offsetY=0, originX=0.5, originY=0.5, worldWidth=0, worldHeight=0.
+- Source: `packages/shaders/src/shaders/static-radial-gradient.ts`, `packages/shaders-react/src/shaders/static-radial-gradient.tsx`, `docs/src/shader-defs/static-radial-gradient-def.ts`.
+
+| Prop | Type | Required | React default | Constraints | Effect |
+| --- | --- | --- | --- | --- | --- |
+| `colorBack` | `string` | no | `"#000000"` | — | Background color |
+| `colors` | `string[]` | no | `["#00bbff","#00ffe1","#ffffff"]` | — | Colors used by the shader; implementation capacity is 10. |
+| `radius` | `number` | no | `0.8` | editor range: 0…3 | The size of the shape |
+| `focalDistance` | `number` | no | `0.99` | editor range: 0…3 | Distance of the focal point from center |
+| `focalAngle` | `number` | no | `0` | editor range: 0…360 | Angle of the focal point in degrees (effective with focalDistance > 0) |
+| `falloff` | `number` | no | `0.24` | editor range: -1…1 | Gradient decay (0 for linear gradient) |
+| `mixing` | `number` | no | `0.5` | editor range: 0…1 | Blending behavior: 0 gives hard stripes and 1 gives a smooth gradient |
+| `distortion` | `number` | no | `0` | editor range: 0…1 | Strength of radial distortion |
+| `distortionShift` | `number` | no | `0` | editor range: -1…1 | Radial distortion offset (effective with distortion > 0) |
+| `distortionFreq` | `number` | no | `12` | editor range: 0…20; step: 1 | Radial distortion frequency (effective with distortion > 0) |
+| `grainMixer` | `number` | no | `0` | editor range: 0…1 | Strength of grain distortion applied to the shapes’ edges |
+| `grainOverlay` | `number` | no | `0` | editor range: 0…1 | Post-processing b/w grain overlay |

--- a/skills/paper-shaders/references/shaders/swirl.md
+++ b/skills/paper-shaders/references/shaders/swirl.md
@@ -1,0 +1,22 @@
+# Swirl
+
+Use the listed implementation types, options, capacities, exports, and defaults. Values labeled “editor range” come from the documentation UI definitions; the component does not clamp props to that range.
+
+Animated bands of color twisting and bending, producing spirals, arcs, and flowing circular patterns.
+
+- React: `Swirl` and `swirlPresets` from `@paper-design/shaders-react`.
+- Vanilla: `swirlFragmentShader` and `SwirlParams` from `@paper-design/shaders`.
+- Common controls: sizing and motion. Defaults: speed=0.32, frame=0, fit="contain", scale=1, rotation=0, offsetX=0, offsetY=0, originX=0.5, originY=0.5, worldWidth=0, worldHeight=0.
+- Source: `packages/shaders/src/shaders/swirl.ts`, `packages/shaders-react/src/shaders/swirl.tsx`, `docs/src/shader-defs/swirl-def.ts`.
+
+| Prop | Type | Required | React default | Constraints | Effect |
+| --- | --- | --- | --- | --- | --- |
+| `colorBack` | `string` | no | `"#330000"` | — | Background color |
+| `colors` | `string[]` | no | `["#ffd1d1","#ff8a8a","#660000"]` | — | Colors used by the shader; implementation capacity is 10. |
+| `bandCount` | `number` | no | `4` | editor range: 0…15; step: 1 | Number of color bands (0 for concentric ripples) |
+| `twist` | `number` | no | `0.1` | editor range: 0…1 | Vortex power (0 = straight sectoral shapes) |
+| `center` | `number` | no | `0.2` | editor range: 0…1 | How far from the center the swirl colors begin to appear |
+| `proportion` | `number` | no | `0.5` | editor range: 0…1 | Blend point between colors (0.5 = equal distribution) |
+| `softness` | `number` | no | `0` | editor range: 0…1 | Color transition sharpness (0 = hard edge, 1 = smooth gradient) |
+| `noiseFrequency` | `number` | no | `0.4` | editor range: 0…1 | Noise frequency (no effect with noise = 0) |
+| `noise` | `number` | no | `0.2` | editor range: 0…1 | Strength of noise distortion (no effect with noiseFrequency = 0) |

--- a/skills/paper-shaders/references/shaders/voronoi.md
+++ b/skills/paper-shaders/references/shaders/voronoi.md
@@ -1,0 +1,21 @@
+# Voronoi
+
+Use the listed implementation types, options, capacities, exports, and defaults. Values labeled “editor range” come from the documentation UI definitions; the component does not clamp props to that range.
+
+Anti-aliased animated Voronoi pattern with smooth and customizable edges.
+
+- React: `Voronoi` and `voronoiPresets` from `@paper-design/shaders-react`.
+- Vanilla: `voronoiFragmentShader` and `VoronoiParams` from `@paper-design/shaders`.
+- Common controls: sizing and motion. Defaults: speed=0.5, frame=0, fit="none", scale=0.5, rotation=0, offsetX=0, offsetY=0, originX=0.5, originY=0.5, worldWidth=0, worldHeight=0.
+- Vanilla requirements: create `u_noiseTexture` with `getShaderNoiseTexture()` and wait for the image to load before constructing `ShaderMount`.
+- Source: `packages/shaders/src/shaders/voronoi.ts`, `packages/shaders-react/src/shaders/voronoi.tsx`, `docs/src/shader-defs/voronoi-def.ts`.
+
+| Prop | Type | Required | React default | Constraints | Effect |
+| --- | --- | --- | --- | --- | --- |
+| `colors` | `string[]` | no | `["#ff8247","#ffe53d"]` | — | Colors used by the shader; implementation capacity is 5. |
+| `stepsPerColor` | `number` | no | `3` | editor range: 1…3; step: 1 | Number of extra colors between base colors (1 = N color palette, 2 = 2×N color palette, 3 = 3×N color palette, etc) |
+| `colorGap` | `string` | no | `"#2e0000"` | — | Color used for cell borders/gaps |
+| `colorGlow` | `string` | no | `"#ffffff"` | — | Color tint for the radial inner shadow effect inside cells (effective with glow > 0) |
+| `distortion` | `number` | no | `0.4` | editor range: 0…0.5 | Strength of noise-driven displacement of cell centers |
+| `gap` | `number` | no | `0.04` | editor range: 0…0.1 | Width of the border/gap between cells |
+| `glow` | `number` | no | `0` | editor range: 0…1 | Strength of the radial inner shadow inside cells |

--- a/skills/paper-shaders/references/shaders/warp.md
+++ b/skills/paper-shaders/references/shaders/warp.md
@@ -1,0 +1,23 @@
+# Warp
+
+Use the listed implementation types, options, capacities, exports, and defaults. Values labeled “editor range” come from the documentation UI definitions; the component does not clamp props to that range.
+
+Animated color fields warped by noise and swirls, applied over base patterns (checks, stripes, or split edge). Blends up to 10 colors with adjustable distribution, softness, distortion, and swirl. Great for fluid, smoky, or marbled effects.
+
+- React: `Warp` and `warpPresets` from `@paper-design/shaders-react`.
+- Vanilla: `warpFragmentShader` and `WarpParams` from `@paper-design/shaders`.
+- Common controls: sizing and motion. Defaults: speed=1, frame=0, fit="none", scale=1, rotation=0, offsetX=0, offsetY=0, originX=0.5, originY=0.5, worldWidth=0, worldHeight=0.
+- Vanilla requirements: create `u_noiseTexture` with `getShaderNoiseTexture()` and wait for the image to load before constructing `ShaderMount`.
+- Source: `packages/shaders/src/shaders/warp.ts`, `packages/shaders-react/src/shaders/warp.tsx`, `docs/src/shader-defs/warp-def.ts`.
+
+| Prop | Type | Required | React default | Constraints | Effect |
+| --- | --- | --- | --- | --- | --- |
+| `colors` | `string[]` | no | `["#121212","#9470ff","#121212","#8838ff"]` | — | Colors used by the shader; implementation capacity is 10. |
+| `rotation` | `number` | no | `0` | editor range: 0…360 | Overall rotation angle of the graphics. |
+| `proportion` | `number` | no | `0.45` | editor range: 0…1 | Blend point between 2 colors (0.5 = equal distribution) |
+| `softness` | `number` | no | `1` | editor range: 0…1 | Color transition sharpness (0 = hard edge, 1 = smooth gradient) |
+| `shape` | `WarpPattern` | no | `"checks"` | options: "checks", "stripes", "edge" | Base pattern type |
+| `shapeScale` | `number` | no | `0.1` | editor range: 0…1 | Zoom level of the base pattern |
+| `distortion` | `number` | no | `0.25` | editor range: 0…1 | Strength of noise-based distortion |
+| `swirl` | `number` | no | `0.8` | editor range: 0…1 | Strength of the swirl distortion |
+| `swirlIterations` | `number` | no | `10` | editor range: 0…20; hard loop capacity: 20 | Exclusive integer loop bound for layered swirl passes. For an integer `N` in the editor range, the shader executes indices 1 through `N - 1`; the default 10 therefore runs 9 passes, and 20 runs 19. Values of 21 or more reach the hard 20-pass loop capacity. |

--- a/skills/paper-shaders/references/shaders/water.md
+++ b/skills/paper-shaders/references/shaders/water.md
@@ -1,0 +1,24 @@
+# Water
+
+Use the listed implementation types, options, capacities, exports, and defaults. Values labeled “editor range” come from the documentation UI definitions; the component does not clamp props to that range.
+
+Water-like surface distortion with natural caustic realism. Works as an image filter or standalone animated texture.
+
+- React: `Water` and `waterPresets` from `@paper-design/shaders-react`.
+- Vanilla: `waterFragmentShader` and `WaterParams` from `@paper-design/shaders`.
+- Common controls: sizing and motion. Defaults: speed=1, frame=0, fit="contain", scale=0.8, rotation=0, offsetX=0, offsetY=0, originX=0.5, originY=0.5, worldWidth=0, worldHeight=0.
+- Vanilla requirements: pass `["u_image"]` as the `ShaderMount` mipmaps argument.
+- Source: `packages/shaders/src/shaders/water.ts`, `packages/shaders-react/src/shaders/water.tsx`, `docs/src/shader-defs/water-def.ts`.
+
+| Prop | Type | Required | React default | Constraints | Effect |
+| --- | --- | --- | --- | --- | --- |
+| `image` | `HTMLImageElement \| string` | no | `""` | — | The image to use for the effect |
+| `colorBack` | `string` | no | `"#909090"` | — | Background color |
+| `colorHighlight` | `string` | no | `"#ffffff"` | — | Highlight color |
+| `highlights` | `number` | no | `0.07` | editor range: 0…1 | A coloring added over the image/background, following the caustic shape |
+| `layering` | `number` | no | `0.5` | editor range: 0…1 | The power of 2nd layer of caustic distortion |
+| `edges` | `number` | no | `0.8` | editor range: 0…1 | Caustic distortion power on the image edges |
+| `caustic` | `number` | no | `0.1` | editor range: 0…1 | Power of caustic distortion |
+| `waves` | `number` | no | `0.3` | editor range: 0…1 | Additional distortion based on simplex noise, independent from caustic |
+| `size` | `number` | no | `1` | editor range: 0.01…7 | Pattern scale relative to the image |
+| `effectScale` | `number` | no | — | — | React-only. @deprecated use `size` instead |

--- a/skills/paper-shaders/references/shaders/waves.md
+++ b/skills/paper-shaders/references/shaders/waves.md
@@ -1,0 +1,23 @@
+# Waves
+
+Use the listed implementation types, options, capacities, exports, and defaults. Values labeled “editor range” come from the documentation UI definitions; the component does not clamp props to that range.
+
+Static line pattern configurable into textures ranging from sharp zigzags to smooth flowing waves.
+
+- React: `Waves` and `wavesPresets` from `@paper-design/shaders-react`.
+- Vanilla: `wavesFragmentShader` and `WavesParams` from `@paper-design/shaders`.
+- Common controls: sizing. Defaults: fit="none", scale=0.6, rotation=0, offsetX=0, offsetY=0, originX=0.5, originY=0.5, worldWidth=0, worldHeight=0.
+- React performance override: `maxPixelCount` defaults to `6016 * 3384`.
+- Source: `packages/shaders/src/shaders/waves.ts`, `packages/shaders-react/src/shaders/waves.tsx`, `docs/src/shader-defs/waves-def.ts`.
+
+| Prop | Type | Required | React default | Constraints | Effect |
+| --- | --- | --- | --- | --- | --- |
+| `colorFront` | `string` | no | `"#ffbb00"` | — | Foreground color |
+| `colorBack` | `string` | no | `"#000000"` | — | Background color |
+| `rotation` | `number` | no | `0` | editor range: 0…360 | Overall rotation angle of the graphics. |
+| `shape` | `number` | no | `0` | editor range: 0…3 | Line shape control: zigzag at 0, sine at 1, one irregular waveform at 2, and a second irregular waveform at 3. Intermediate values morph gradually between adjacent shapes. |
+| `frequency` | `number` | no | `0.5` | editor range: 0…2 | Wave frequency |
+| `amplitude` | `number` | no | `0.5` | editor range: 0…1 | Wave amplitude |
+| `spacing` | `number` | no | `1.2` | editor range: 0…2 | The space between every two wavy lines |
+| `proportion` | `number` | no | `0.1` | editor range: 0…1 | Blend point between front and back colors (0.5 = equal distribution) |
+| `softness` | `number` | no | `0` | editor range: 0…1 | Color transition sharpness (0 = hard edge, 1 = smooth gradient) |

--- a/skills/paper-shaders/references/usage.md
+++ b/skills/paper-shaders/references/usage.md
@@ -1,0 +1,285 @@
+# Paper Shaders usage
+
+This reference is derived from:
+
+- `packages/shaders/src/index.ts`
+- `packages/shaders/src/shader-mount.ts`
+- `packages/shaders/src/shader-sizing.ts`
+- `packages/shaders/src/get-shader-color-from-string.ts`
+- `packages/shaders-react/src/index.ts`
+- `packages/shaders-react/src/shader-mount.tsx`
+- `packages/shaders-react/src/shaders/*.tsx`
+
+Read the matching file under [Shader references](../SKILL.md#shader-references) for shader-specific props, defaults, ranges, enum options, exports, capacities, and special vanilla requirements.
+
+## Contents
+
+- [Packages](#packages)
+- [React](#react)
+  - [Presets](#presets)
+  - [Low-level React mount](#low-level-react-mount)
+- [Vanilla](#vanilla)
+  - [Convert React props to vanilla uniforms](#convert-react-props-to-vanilla-uniforms)
+  - [Noise textures](#noise-textures)
+  - [Images](#images)
+  - [Preprocessed image shaders](#preprocessed-image-shaders)
+  - [Color syntax](#color-syntax)
+- [Common sizing and motion](#common-sizing-and-motion)
+- [Verification](#verification)
+
+## Packages
+
+- React: `@paper-design/shaders-react`
+- Vanilla JavaScript or TypeScript: `@paper-design/shaders`
+
+The repository README asks consumers to pin the dependency because breaking changes may ship under `0.0.x` versioning. Match the project's existing package manager and version policy.
+
+## React
+
+Use the named component exported by `@paper-design/shaders-react`.
+
+```tsx
+import { MeshGradient } from '@paper-design/shaders-react';
+
+export function HeroShader() {
+  return (
+    <MeshGradient
+      colors={['#e0eaff', '#241d9a', '#f75092', '#9f50d3']}
+      distortion={0.8}
+      swirl={0.1}
+      grainMixer={0}
+      grainOverlay={0}
+      speed={1}
+      width="100%"
+      height={320}
+    />
+  );
+}
+```
+
+Every named shader component accepts its shader-specific params plus the common component controls:
+
+- ordinary `div` props except `color` and `ref`
+- `ref?: React.Ref<PaperShaderElement>`
+- `width?: string | number`
+- `height?: string | number`
+- `minPixelRatio?: number`
+- `maxPixelCount?: number`
+- `webGlContextAttributes?: WebGLContextAttributes`
+
+`width` and `height` become inline styles. Other layout styles can be passed through `style`. Ensure the element resolves to a non-zero width and height.
+
+### Presets
+
+Each named React component has a corresponding exported preset array, such as `meshGradientPresets`. Preset `params` contain the shader params plus all sizing defaults and, when the shader supports motion, `speed` and `frame`. Image presets intentionally omit `image`; React-only component controls are also outside preset `params`.
+
+```tsx
+import { MeshGradient, meshGradientPresets } from '@paper-design/shaders-react';
+
+const preset = meshGradientPresets[0].params;
+
+<MeshGradient {...preset} width="100%" height={320} />;
+```
+
+Use the catalog's exact preset export name.
+
+### Low-level React mount
+
+`ShaderMount` from `@paper-design/shaders-react` accepts:
+
+- `fragmentShader`
+- `uniforms`
+- `speed` and `frame`
+- `mipmaps`
+- `minPixelRatio` and `maxPixelCount`
+- `webGlContextAttributes`
+- `width`, `height`, and ordinary supported `div` props
+
+String uniform values are treated as image URLs, not arbitrary string uniforms. Prefer named components for package shaders because they construct and convert uniforms correctly.
+
+## Vanilla
+
+The vanilla package exports fragment shader source and `ShaderMount`; it does not provide named convenience mount functions. Construct the complete uniform object yourself.
+Create and dispose the mount in a browser/client lifecycle: the class requires DOM, `navigator`, canvas, and WebGL APIs.
+
+```ts
+import {
+  ShaderFitOptions,
+  ShaderMount,
+  getShaderColorFromString,
+  meshGradientFragmentShader,
+  type MeshGradientUniforms,
+} from '@paper-design/shaders';
+
+const host = document.querySelector<HTMLElement>('#shader');
+if (!host) throw new Error('Missing #shader element');
+
+const colors = ['#e0eaff', '#241d9a', '#f75092', '#9f50d3'];
+
+const uniforms: MeshGradientUniforms = {
+  u_colors: colors.map(getShaderColorFromString),
+  u_colorsCount: colors.length,
+  u_distortion: 0.8,
+  u_swirl: 0.1,
+  u_grainMixer: 0,
+  u_grainOverlay: 0,
+  u_fit: ShaderFitOptions.contain,
+  u_scale: 1,
+  u_rotation: 0,
+  u_offsetX: 0,
+  u_offsetY: 0,
+  u_originX: 0.5,
+  u_originY: 0.5,
+  u_worldWidth: 0,
+  u_worldHeight: 0,
+};
+
+const mount = new ShaderMount(
+  host,
+  meshGradientFragmentShader,
+  uniforms,
+  undefined,
+  1,
+  0
+);
+
+mount.setUniforms({ u_distortion: 0.5 });
+mount.setSpeed(0.5);
+
+// Call during teardown:
+mount.dispose();
+```
+
+The constructor arguments, in order, are:
+
+1. parent `HTMLElement`
+2. fragment shader string
+3. initial uniform object
+4. optional `WebGLContextAttributes`
+5. speed, default `0`
+6. frame, default `0`
+7. minimum pixel ratio, default `2`
+8. maximum pixel count, default `1920 * 1080 * 4`
+9. uniform names that require mipmaps, default `[]`
+
+The parent receives a prepended canvas, `data-paper-shader`, and `paperShaderMount`. `dispose()` removes the canvas and WebGL resources.
+
+`ShaderMount` supports partial updates with `setUniforms`, and also exposes `getCurrentFrame`, `setFrame`, `setSpeed`, `setMinPixelRatio`, and `setMaxPixelCount`.
+
+### Convert React props to vanilla uniforms
+
+Follow the named React component's `uniforms` object. Apply these source-defined rules:
+
+- Convert each color string with `getShaderColorFromString`.
+- Convert `colors` with `.map(getShaderColorFromString)` and also set `u_colorsCount`.
+- Convert `fit` with `ShaderFitOptions[fit]`.
+- Convert enum props with their exported mapping object, such as `WarpPatterns[shape]`.
+- Pass `speed` and `frame` to `ShaderMount`; they are not shader-specific uniforms.
+- Map common sizing props to `u_fit`, `u_scale`, `u_rotation`, `u_offsetX`, `u_offsetY`, `u_originX`, `u_originY`, `u_worldWidth`, and `u_worldHeight`.
+- Pass booleans as booleans. `ShaderMount` converts them to integer uniforms.
+- Pass textures as fully loaded `HTMLImageElement` instances.
+
+Do not assume every prop becomes `u_${prop}`. These package mappings differ:
+
+- `Dithering.size` and `ImageDithering.size` → `u_pxSize`
+- `DotGrid.size` → `u_dotSize`
+- `FlutedGlass.margin` and `PulsingBorder.margin` → defaults for all four side-specific margin uniforms; an explicitly supplied side value wins
+- `width`, `height`, `minPixelRatio`, `maxPixelCount`, `webGlContextAttributes`, and `ref` configure the mount/container and are not uniforms
+- `suspendWhenProcessingImage` and deprecated compatibility props are React-only
+
+Always inspect the catalog's source paths when constructing a vanilla shader. The uniform interfaces in `packages/shaders/src/shaders/*.ts` list the complete required uniform object.
+
+### Noise textures
+
+For shaders whose catalog says to set `u_noiseTexture`, import `getShaderNoiseTexture` and include:
+
+```ts
+const noiseTexture = getShaderNoiseTexture();
+if (!noiseTexture) throw new Error('Noise textures require a browser');
+await noiseTexture.decode();
+
+// Include in the initial uniforms:
+u_noiseTexture: noiseTexture
+```
+
+The source returns `undefined` outside the browser and a newly created `HTMLImageElement` in the browser. Wait for it to load before constructing the vanilla `ShaderMount`; the mount rejects incomplete images. The React mount performs this wait itself.
+
+### Images
+
+The low-level vanilla mount accepts `HTMLImageElement`, not URL strings. The image must be fully loaded and have a non-zero `naturalWidth`; otherwise mounting the texture throws.
+
+The React mount accepts an `HTMLImageElement` or a string that is either:
+
+- an absolute path beginning with `/`
+- a URL accepted by `new URL(value)`
+- an empty string, which becomes a transparent pixel
+
+For an external URL, the React loader sets `crossOrigin = "anonymous"`. When both natural dimensions are below 1024, it sets the image dimensions so the shorter side is 1024 before upload.
+
+When a texture is supplied as `u_image`, `ShaderMount` automatically looks up and fills `u_imageAspectRatio`.
+
+Pass `["u_image"]` as the final vanilla constructor argument when the catalog requires mipmaps.
+
+### Preprocessed image shaders
+
+`Heatmap`, `LiquidMetal`, and `GemSmoke` preprocess image inputs in their React components. Reproduce this in vanilla:
+
+- `toProcessedHeatmap(fileOrUrl)` returns `{ blob }`
+- `toProcessedLiquidMetal(fileOrUrl)` returns `{ imageData, pngBlob }`
+- `toProcessedGemSmoke(fileOrUrl)` returns `{ imageData, pngBlob }`
+
+Each function accepts `File | string` and requires browser document/canvas APIs. Load the returned blob into an `HTMLImageElement`, pass that loaded image as `u_image`, and enable mipmaps for `u_image`.
+
+For `LiquidMetal` and `GemSmoke`, also set `u_isImage` from whether an original image was supplied and convert `shape` with `LiquidMetalShapes` or `GemSmokeShapes`. When no original image is supplied, load the exported `emptyPixel` into an `HTMLImageElement`, use that placeholder as the initial `u_image`, and set `u_isImage` to `false`; the shader still declares and samples `u_image`.
+
+### Color syntax
+
+`getShaderColorFromString` supports:
+
+- 3-, 4-, 6-, and 8-digit hex
+- comma-form `rgb(...)` and `rgba(...)`
+- comma-form `hsl(...)` and `hsla(...)`
+- already-normalized RGB or RGBA number tuples when calling the utility directly
+
+It does not parse CSS named colors. Invalid values fall back to `[0.5, 0.5, 0.5, 1]`.
+
+## Common sizing and motion
+
+All named shader components accept:
+
+- `fit?: "none" | "contain" | "cover"`
+- `scale?: number`
+- `rotation?: number`
+- `originX?: number`
+- `originY?: number`
+- `offsetX?: number`
+- `offsetY?: number`
+- `worldWidth?: number`
+- `worldHeight?: number`
+
+Defaults come from one of two source objects, then may be overridden by the component's default preset:
+
+- `defaultObjectSizing`: `fit="contain"` and otherwise `scale=1`, `rotation=0`, offsets `0`, origins `0.5`, and world dimensions `0`
+- `defaultPatternSizing`: the same values except `fit="none"`
+
+The catalog lists the effective defaults for every shader.
+
+Shaders whose params extend `ShaderMotionParams` also accept:
+
+- `speed?: number`: `0` stops the animation loop; negative values play backward
+- `frame?: number`: animation position in milliseconds; the shader receives seconds as `u_time`
+
+The mount pauses animated rendering when the document is hidden. It also pauses when the element leaves the viewport when `IntersectionObserver` is available in the element's window.
+
+`minPixelRatio` defaults to `2`. `maxPixelCount` defaults to `1920 * 1080 * 4` physical pixels. The `Waves` React component overrides its `maxPixelCount` default to `6016 * 3384`.
+The `DotGrid` React component uses the same `6016 * 3384` override.
+
+## Verification
+
+- Type-check against the installed package version.
+- Confirm the mount has a non-zero layout size.
+- Confirm all initial vanilla uniforms are present.
+- Confirm color arrays are non-empty and do not exceed the implementation capacity in the catalog.
+- Confirm image inputs load and satisfy CORS rules.
+- Confirm preprocessors run only in a browser environment.
+- Call `dispose()` for vanilla mounts during teardown.


### PR DESCRIPTION
This PR adds skill files for Paper Shaders, so we can add the skill to our projects like this
```
npx skills add paper-design/shaders
```
And agents would know how to use or customize each shader.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only additions under `skills/`; no runtime, build, or application code changes.
> 
> **Overview**
> Adds a **`paper-shaders`** agent skill under `skills/paper-shaders/` so projects can install it (e.g. `npx skills add paper-design/shaders`) and coding agents follow a consistent integration workflow for `@paper-design/shaders-react` and `@paper-design/shaders`.
> 
> **`SKILL.md`** defines the workflow (read usage + per-shader refs, prefer named React components, mirror React uniform construction in vanilla), treats package source as authoritative over docs UI ranges, and lists implementation rules (public exports only, full initial vanilla uniforms, dispose mounts, color limits, no CSS named colors).
> 
> **`references/usage.md`** documents React and vanilla mounting, presets, prop→uniform conversion (including non-obvious mappings), noise textures, images, preprocessors for Heatmap/Liquid Metal/Gem Smoke, sizing/motion, and verification.
> 
> **`references/shaders/*.md`** adds one reference per catalog shader (30+ effects) with React/vanilla exports, defaults, editor ranges, capacities, and shader-specific vanilla requirements (noise texture, mipmaps, image preprocessing).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec49c595532f52ad5a79c923e4bdb8efc3d3e984. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->